### PR TITLE
TimeBlock types

### DIFF
--- a/cpp/petsird_analysis.cpp
+++ b/cpp/petsird_analysis.cpp
@@ -18,6 +18,7 @@ using petsird::binary::PETSIRDReader;
 #include <xtensor/xview.hpp>
 #include <xtensor/xio.hpp>
 #include <iostream>
+#include <variant>
 
 int
 main(int argc, char* argv[])
@@ -64,13 +65,17 @@ main(int argc, char* argv[])
   float last_time = 0.F;
   while (reader.ReadTimeBlocks(time_block))
     {
-      last_time = time_block.id * header.scanner.listmode_time_block_duration;
-      num_prompts += time_block.prompt_events.size();
-
-      for (auto& event : time_block.prompt_events)
+      if (std::holds_alternative<petsird::EventTimeBlock>(time_block))
         {
-          energy_1 += energy_mid_points[event.energy_indices[0]];
-          energy_2 += energy_mid_points[event.energy_indices[1]];
+          auto& event_time_block = std::get<petsird::EventTimeBlock>(time_block);
+          last_time = event_time_block.start * header.scanner.listmode_time_block_duration;
+          num_prompts += event_time_block.prompt_events.size();
+
+          for (auto& event : event_time_block.prompt_events)
+            {
+              energy_1 += energy_mid_points[event.energy_indices[0]];
+              energy_2 += energy_mid_points[event.energy_indices[1]];
+            }
         }
     }
 

--- a/cpp/petsird_analysis.cpp
+++ b/cpp/petsird_analysis.cpp
@@ -68,7 +68,7 @@ main(int argc, char* argv[])
       if (std::holds_alternative<petsird::EventTimeBlock>(time_block))
         {
           auto& event_time_block = std::get<petsird::EventTimeBlock>(time_block);
-          last_time = event_time_block.start * header.scanner.listmode_time_block_duration;
+          last_time = event_time_block.start;
           num_prompts += event_time_block.prompt_events.size();
 
           for (auto& event : event_time_block.prompt_events)

--- a/cpp/petsird_generator.cpp
+++ b/cpp/petsird_generator.cpp
@@ -217,8 +217,8 @@ main(int argc, char* argv[])
       std::poisson_distribution<> poisson(COUNT_RATE);
       const auto num_prompts_this_block = poisson(gen);
       const auto prompts_this_block = get_events(header, num_prompts_this_block);
-      petsird::TimeBlock time_block;
-      time_block.id = t;
+      petsird::EventTimeBlock time_block;
+      time_block.start = t * header.scanner.listmode_time_block_duration;
       time_block.prompt_events = prompts_this_block;
       writer.WriteTimeBlocks(time_block);
     }

--- a/cpp/petsird_generator.cpp
+++ b/cpp/petsird_generator.cpp
@@ -129,8 +129,8 @@ get_scanner_info()
     scanner_info.tof_bin_edges = tof_bin_edges;
     scanner_info.tof_resolution = 9.4F; // in mm
     scanner_info.energy_bin_edges = energy_bin_edges;
-    scanner_info.energy_resolution_at_511 = .11F;    // as fraction of 511
-    scanner_info.listmode_time_block_duration = 1.F; // ms
+    scanner_info.energy_resolution_at_511 = .11F; // as fraction of 511
+    scanner_info.event_time_block_duration = 1.F; // ms
   }
 
   return scanner_info;
@@ -218,7 +218,7 @@ main(int argc, char* argv[])
       const auto num_prompts_this_block = poisson(gen);
       const auto prompts_this_block = get_events(header, num_prompts_this_block);
       petsird::EventTimeBlock time_block;
-      time_block.start = t * header.scanner.listmode_time_block_duration;
+      time_block.start = t * header.scanner.event_time_block_duration;
       time_block.prompt_events = prompts_this_block;
       writer.WriteTimeBlocks(time_block);
     }

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -3,6 +3,7 @@ PETSIRD: !protocol
   sequence:
     header: Header
     timeBlocks: !stream
+      # block with information (e.g. events, signals, etc.) occurring at a certain time or in a time interval
       # Note: multiple time blocks can occur at the same start time
       items: TimeBlock
 
@@ -11,11 +12,13 @@ Header: !record
     scanner: ScannerInformation
     exam: ExamInformation?
 
-TimeBlock: [EventTimeBlock, ExternalSignalTimeBlock, BedMovementTimeBlock]
+# types of timeBlocks
+# TODO more types could be needed
+TimeBlock: [EventTimeBlock, ExternalSignalTimeBlock, BedMovementTimeBlock, GantryMovementTimeBlock]
 
 EventTimeBlock: !record
   fields:
-   # start time since startOfAcquisition in ms
+   # start time since ExamInformation.startOfAcquisition in ms
    start: uint
    # TODO encode end time?
    # list of prompts in this time block
@@ -28,34 +31,39 @@ EventTimeBlock: !record
 
 ExternalSignalTypeEnum: !enum
   values:
-    - ECG_trace
-    - ECG_trigger
-    - resp_trace
-    - resp_trigger
-    - other_motion_signal
-    - other_motion_trigger
-    - external_sync
+    - ecgTrace
+    - ecgTrigger
+    - respTrace
+    - respTrigger
+    - otherMotionSignal
+    - otherMotionTrigger
+    - externalSync
     # other options, to be listed in the future
     - other
 
 ExternalSignalType: !record
   fields:
     type: ExternalSignalTypeEnum
-    description: str
+    description: string
     id: uint
 
 ExternalSignalTimeBlock: !record
   fields:
-   # start time since startOfAcquisition in ms
+   # start time since ExamInformation.startOfAcquisition in ms
    start: uint
    # refer to ExternalSignalType.id
-   signal_id: uint
+   signalID: uint
    # Note for triggers, this field is to be ignored
    signalValues: float*
 
-
 BedMovementTimeBlock: !record
   fields:
-    # start time since startOfAcquisition in ms
+    # start time since ExamInformation.startOfAcquisition in ms
+    start: uint
+    transform: RigidTransformation
+
+GantryMovementTimeBlock: !record
+  fields:
+    # start time since ExamInformation.startOfAcquisition in ms
     start: uint
     transform: RigidTransformation

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -3,6 +3,7 @@ PETSIRD: !protocol
   sequence:
     header: Header
     timeBlocks: !stream
+      # Note: multiple time blocks can occur at the same start time
       items: TimeBlock
 
 Header: !record
@@ -10,10 +11,13 @@ Header: !record
     scanner: ScannerInformation
     exam: ExamInformation?
 
-TimeBlock: !record
+TimeBlock: [EventTimeBlock, ExternalSignalTimeBlock, BedMovementTimeBlock]
+
+EventTimeBlock: !record
   fields:
-   # number of the block. Multiply with listmodeTimeBlockDuration to get time since startOfAcquisition
-   id: uint
+   # start time since startOfAcquisition in ms
+   start: uint
+   # TODO encode end time?
    # list of prompts in this time block
    # TODO might be better to use !array
    promptEvents: CoincidenceEvent*
@@ -21,3 +25,37 @@ TimeBlock: !record
    delayedEvents: CoincidenceEvent*?
    # optional list of triple coincidences in this time block
    tripleEvents: TripleEvent*?
+
+ExternalSignalTypeEnum: !enum
+  values:
+    - ECG_trace
+    - ECG_trigger
+    - resp_trace
+    - resp_trigger
+    - other_motion_signal
+    - other_motion_trigger
+    - external_sync
+    # other options, to be listed in the future
+    - other
+
+ExternalSignalType: !record
+  fields:
+    type: ExternalSignalTypeEnum
+    description: str
+    id: uint
+
+ExternalSignalTimeBlock: !record
+  fields:
+   # start time since startOfAcquisition in ms
+   start: uint
+   # refer to ExternalSignalType.id
+   signal_id: uint
+   # Note for triggers, this field is to be ignored
+   signalValues: float*
+
+
+BedMovementTimeBlock: !record
+  fields:
+    # start time since startOfAcquisition in ms
+    start: uint
+    transform: RigidTransformation

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -19,6 +19,7 @@ TimeBlock: [EventTimeBlock, ExternalSignalTimeBlock, BedMovementTimeBlock, Gantr
 EventTimeBlock: !record
   fields:
    # start time since ExamInformation.startOfAcquisition in ms
+   # Note: duration is given by ScannerInformation.eventTimeBlockDuration
    start: uint
    # TODO encode end time?
    # list of prompts in this time block

--- a/model/ScannerInformation.yml
+++ b/model/ScannerInformation.yml
@@ -52,8 +52,8 @@ ScannerInformation: !record
     # FWHM of photopeak for incoming gamma of 511 keV, expressed as a ratio w.r.t. 511
     energyResolutionAt511: float
 
-    # duration of each time block in ms
-    listmodeTimeBlockDuration: uint
+    # duration of each event time block in ms
+    eventTimeBlockDuration: uint
 
     # Encode how the scanner handles multiple coincidences
     coincidencePolicy: CoincidencePolicy

--- a/python/petsird_analysis.py
+++ b/python/petsird_analysis.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
         num_prompts = 0
         last_time = 0
         for time_block in reader.read_time_blocks():
-            last_time = time_block.value.start  # all TimeBlock types have this field
             if isinstance(time_block, petsird.TimeBlock.EventTimeBlock):
+                last_time = time_block.value.start  # all TimeBlock types have this field
                 num_prompts += len(time_block.value.prompt_events)
                 for event in time_block.value.prompt_events:
                     energy_1 += energy_mid_points[event.energy_indices[0]]

--- a/python/petsird_analysis.py
+++ b/python/petsird_analysis.py
@@ -37,11 +37,12 @@ if __name__ == "__main__":
         num_prompts = 0
         last_time = 0
         for time_block in reader.read_time_blocks():
-            last_time = time_block.id * header.scanner.listmode_time_block_duration
-            num_prompts += len(time_block.prompt_events)
-            for event in time_block.prompt_events:
-                energy_1 += energy_mid_points[event.energy_indices[0]]
-                energy_2 += energy_mid_points[event.energy_indices[1]]
+            last_time = time_block.value.start  # all TimeBlock types have this field
+            if isinstance(time_block, petsird.TimeBlock.EventTimeBlock):
+                num_prompts += len(time_block.value.prompt_events)
+                for event in time_block.value.prompt_events:
+                    energy_1 += energy_mid_points[event.energy_indices[0]]
+                    energy_2 += energy_mid_points[event.energy_indices[1]]
 
         print(f"Last time block at {last_time} ms")
         print(f"Number of prompt events: {num_prompts}")

--- a/python/petsird_generator.py
+++ b/python/petsird_generator.py
@@ -119,7 +119,7 @@ def get_scanner_info() -> petsird.ScannerInformation:
         tof_resolution=9.4,  # in mm
         energy_bin_edges=energyBinEdges,
         energy_resolution_at_511=0.11,  # as fraction of 511
-        listmode_time_block_duration=1,  # ms
+        event_time_block_duration=1,  # ms
     )
 
 
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         header = get_header()
         writer.write_header(header)
         for t in range(NUMBER_OF_TIME_BLOCKS):
-            start = t * header.scanner.listmode_time_block_duration
+            start = t * header.scanner.event_time_block_duration
             num_prompts_this_block = rng.poisson(COUNT_RATE)
             prompts_this_block = list(get_events(header, num_prompts_this_block))
             # Normally we'd write multiple blocks, but here we have just one, so let's write a tuple with just one element

--- a/python/petsird_generator.py
+++ b/python/petsird_generator.py
@@ -162,9 +162,16 @@ if __name__ == "__main__":
         header = get_header()
         writer.write_header(header)
         for t in range(NUMBER_OF_TIME_BLOCKS):
+            start = t * header.scanner.listmode_time_block_duration
             num_prompts_this_block = rng.poisson(COUNT_RATE)
             prompts_this_block = list(get_events(header, num_prompts_this_block))
             # Normally we'd write multiple blocks, but here we have just one, so let's write a tuple with just one element
             writer.write_time_blocks(
-                (petsird.TimeBlock(id=t, prompt_events=prompts_this_block),)
+                (
+                    petsird.TimeBlock.EventTimeBlock(
+                        petsird.EventTimeBlock(
+                            start=start, prompt_events=prompts_this_block
+                        )
+                    ),
+                )
             )


### PR DESCRIPTION
This PR introduces different types of `TimeBlock`s, one for coincidence/triple events, one for external signals, one for bed movement and one for gantry movement.

Having different types makes sure that we can have different time resolution for the different types, e.g. different external signals will have different sampling rates etc.

We have chosen to signals to be a union of different types as well. Alternatively, we could have introduced different types of `signalTimeBlock`. However, that seems to need more `if` statements in the main loop (one for every signal-type), which could be more wasteful and less future proof, but maybe it's just a matter of taste...