### PR TITLE
CI: build artefact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         ./petsird_analysis test.h5
     - uses: casperdcl/deploy-pypi@v2
       with:
-        build: -s python -o dist
+        build: python -o dist
         upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
       with:
         build: -s python -o dist
         upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: casperdcl/deploy-pypi@v2
+    - uses: actions/upload-artifact@v4
       with:
-        url: https://test.pypi.org/legacy/
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        name: python-petsird
+        path: dist/**


### PR DESCRIPTION
- use GH build art[ie]facts in lieu of testpypi (*really* fixes #39)
  + alternative to https://github.com/pypa/setuptools-scm/issues/455
- also build `*.whl` as well as `*.tar.gz` (follow-up to #40)

[![image](https://github.com/user-attachments/assets/7a9709f0-f0a7-48e8-abe5-cf6ab6bc964b)](https://github.com/ETSInitiative/PETSIRD/actions/runs/11593615920)