### PR TITLE
use root licen[cs]e in python

### DIFF
--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,1 @@
+../LICENSE.txt


### PR DESCRIPTION
Simple symlink.

- fixes #51

/cc @gschramm