### PR TITLE
Add justfile to streamline build/test loop

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,24 @@ else()
   add_compile_options(-Wall -Wextra -pedantic)
 endif()
 
+SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
+
+# Enable ccache if not already enabled by symlink masquerading and if no other
+# CMake compiler launchers are already defined
+find_program(CCACHE_EXECUTABLE ccache)
+mark_as_advanced(CCACHE_EXECUTABLE)
+if(CCACHE_EXECUTABLE)
+  message(STATUS "ccache found")
+  foreach(LANG C CXX)
+    if(NOT DEFINED CMAKE_${LANG}_COMPILER_LAUNCHER AND NOT CMAKE_${LANG}_COMPILER MATCHES ".*/ccache")
+      message(STATUS "Enabling ccache for ${LANG}")
+      set(CMAKE_${LANG}_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE} CACHE STRING "")
+    endif()
+  endforeach()
+else()
+  message(STATUS "ccache not found")
+endif()
+
 add_executable(petsird_generator petsird_generator.cpp)
 target_link_libraries(petsird_generator petsird_generated)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,22 +9,10 @@ else()
   add_compile_options(-Wall -Wextra -pedantic)
 endif()
 
-SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
-
-# Enable ccache if not already enabled by symlink masquerading and if no other
-# CMake compiler launchers are already defined
-find_program(CCACHE_EXECUTABLE ccache)
-mark_as_advanced(CCACHE_EXECUTABLE)
-if(CCACHE_EXECUTABLE)
-  message(STATUS "ccache found")
-  foreach(LANG C CXX)
-    if(NOT DEFINED CMAKE_${LANG}_COMPILER_LAUNCHER AND NOT CMAKE_${LANG}_COMPILER MATCHES ".*/ccache")
-      message(STATUS "Enabling ccache for ${LANG}")
-      set(CMAKE_${LANG}_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE} CACHE STRING "")
-    endif()
-  endforeach()
-else()
-  message(STATUS "ccache not found")
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+  message(STATUS "ccache found, so we will use it.")
 endif()
 
 add_executable(petsird_generator petsird_generator.cpp)

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,6 @@ dependencies:
   - ccache=4.5.1
   - cmake>=3.21.3
   - compilers
-  - fmt>=8.1.1
-  - gdb>=11.2
   - h5py>=3.7.0
   - hdf5>=1.12.1
   - howardhinnant_date>=3.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,18 +4,21 @@ channels:
   - defaults
 dependencies:
   - bash-completion>=2.11
+  - ccache=4.5.1
   - cmake>=3.21.3
-  - fmt>=8.1.1
   - compilers
+  - fmt>=8.1.1
+  - gdb>=11.2
   - h5py>=3.7.0
   - hdf5>=1.12.1
   - howardhinnant_date>=3.0.1
   - ipykernel>=6.19.2
+  - just>=1.36.0
+  - matplotlib
   - ninja>=1.11.0
   - nlohmann_json>=3.11.2
   - numpy>=1.24.3
   - python>=3.11.3
-  - matplotlib
   - shellcheck>=0.8.0
   - xtensor-fftw>=0.2.5
   - xtensor>=0.24.2

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+set shell := ['bash', '-ceuo', 'pipefail']
+
+@default: build
+
+@configure:
+    mkdir -p cpp/build; \
+    cd cpp/build; \
+    cmake -GNinja ..
+
+@ensure-configured:
+    if [ ! -f cpp/build/CMakeCache.txt ]; then \
+        just configure; \
+    fi
+
+@generate:
+    cd model && yardl generate
+
+@build: generate ensure-configured
+    cd cpp/build && ninja
+
+@run: run-cpp run-python
+
+@run-cpp: build
+    #!/usr/bin/env bash
+    cd cpp/build
+    ./petsird_generator testdata.petsird
+    ./petsird_analysis testdata.petsird
+    rm -f testdata.petsird
+
+@run-python: generate
+    #!/usr/bin/env bash
+    cd python
+    python petsird_generator.py | python petsird_analysis.py


### PR DESCRIPTION
## Changes in this pull request

Add a `justfile` and `ccache` to speed up the C++ build loop.

## Testing performed

Run `just` repeatedly to build the C++ code only when the model changes.
Run `just run` to run a simple exercise of both the C++ and Python generator and analysis tools.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
