### PR TITLE
Bug fix in petsird_helpers.h

### DIFF
--- a/cpp/petsird_helpers.h
+++ b/cpp/petsird_helpers.h
@@ -56,16 +56,16 @@ get_detection_efficiency(const ScannerInformation& scanner, const CoincidenceEve
 {
   float eff = 1.0F;
   const auto& det_el_efficiencies = scanner.detection_efficiencies.det_el_efficiencies;
-  if (!det_el_efficiencies)
+  if (det_el_efficiencies)
     {
       eff *= ((*det_el_efficiencies)(event.detector_ids[0], event.energy_indices[0])
               * (*det_el_efficiencies)(event.detector_ids[1], event.energy_indices[1]));
     }
   const auto& module_pair_efficiencies_vector = scanner.detection_efficiencies.module_pair_efficiencies_vector;
-  if (!module_pair_efficiencies_vector)
+  if (module_pair_efficiencies_vector)
     {
       const auto& module_pair_SGID_LUT = scanner.detection_efficiencies.module_pair_sgidlut;
-      assert(!module_pair_SGID_LUT);
+      assert(module_pair_SGID_LUT);
 
       const auto mod_and_els = get_module_and_element(scanner.scanner_geometry, event.detector_ids);
       assert(scanner.scanner_geometry.replicated_modules.size() == 1);


### PR DESCRIPTION
In the get_detection_efficiency() function, there were some safety checks that did the opposite of what they were supposed to.

## Changes in this pull request


## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following:

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
