### PR TITLE
introduce DetectorId type

### DIFF
--- a/model/CoincidenceEvent.yml
+++ b/model/CoincidenceEvent.yml
@@ -1,9 +1,9 @@
-# All information about a coincidence event specified as identifiers or indices (i.e. discretized). Indices start from 0.
+# All information about a coincidence event specified as identifiers (i.e. discretized).
 # TODO: this might take up too much space, so some/all of these could be combined in a single index if necessary.
 CoincidenceEvent: !record
   fields:
-    # the pair of detector elements
-    detectorIds: uint*2
+    # identifiers of the two detecting elements (see doc for DetectorId)
+    detectorIds: DetectorId*2
     # an index into the tofBinEdges field in the ScannerInformation
     tofIdx: uint
     # a pair of indices into the energyBinEdges field in the ScannerInformation

--- a/model/DetectorInformation.yml
+++ b/model/DetectorInformation.yml
@@ -40,3 +40,15 @@ ScannerGeometry: !record
     ids: uint*
     # shielding etc
     nonDetectingVolumes: GenericSolidVolume*?
+
+# This is the type for detector IDs using in `CoincidenceEvent` and `TripleEvent`.
+# It is an unsigned integer that runs over all the "elementary detector elements" (aka crystals),
+# starting from 0.
+# The correspondence between this integer and a module/det_el is not decided (TODO),
+# but the current proposal is to effectively increment the detectorID in nested loops:
+# 1. ScannerGeometry.replicated_modules
+# 2. replicated_module.transforms
+# 3. replicated_module.detecting_elements
+# 4. detecting_element.transforms
+# (with therefore the detector IDs running faster over the 4th loop)
+DetectorID: uint

--- a/model/DetectorInformation.yml
+++ b/model/DetectorInformation.yml
@@ -51,4 +51,4 @@ ScannerGeometry: !record
 # 3. replicated_module.detecting_elements
 # 4. detecting_element.transforms
 # (with therefore the detector IDs running faster over the 4th loop)
-DetectorID: uint
+DetectorId: uint

--- a/model/TripleEvent.yml
+++ b/model/TripleEvent.yml
@@ -1,7 +1,10 @@
-# All information about a triple event specified as identifiers or indices (i.e. discretized).
+# All information about a triple event specified as identifiers (i.e. discretized).
 TripleEvent: !record
   fields:
-    detectorIds: uint*3
+    # Identifiers of the three detecting elements (see doc for DetectorId)
+    # Note that it is possible that 2 detectorIDs are equal (e.g. for
+    # inter-crystal Compton events)
+    detectorIds: DetectorId*3
     # timing differences (converted to mm) w.r.t. first event, stored as
     # indices into the tofBinEdges field in the ScannerInformation
     # Note: only 2, corresponding to the arrival time differences of the second and third detectorId


### PR DESCRIPTION
Replace `uint` with an alias type `DetectorId`, to allow future flexibility but also single place for documentation.

[x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
