### PR TITLE
remove work-around for twine bug

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,14 +14,13 @@ authors = [
 maintainers = [
     {name = "Casper da Costa-Luis", email = "imaging@cdcl.ml"},
     {name = "Kris Thielemans", email = "k.thielemans@ucl.ac.uk"}]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.22",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,9 +32,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Medical Science Apps."]
 
-[tool.setuptools]
-license-files = [] # see https://github.com/pypa/twine/issues/1216#issuecomment-2609745412
-
 [tool.setuptools.packages.find]
 include = ["petsird", "petsird.*"]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,6 +15,7 @@ maintainers = [
     {name = "Casper da Costa-Luis", email = "imaging@cdcl.ml"},
     {name = "Kris Thielemans", email = "k.thielemans@ucl.ac.uk"}]
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.22",


### PR DESCRIPTION
As https://github.com/pypa/twine/pull/1216 is now fixed, remove our workaround.

With any luck, it fixes the problem in https://github.com/conda-forge/petsird-feedstock/pull/1 that the license file isn't packaged.