### PR TITLE
convert energies to float64 before summing them in analysis script

### DIFF
--- a/python/petsird/helpers/analysis.py
+++ b/python/petsird/helpers/analysis.py
@@ -111,10 +111,10 @@ if __name__ == "__main__":
                                 scanner, mtype1, event.detection_bins[1])
 
                             # accumulate energies to print average below
-                            energy_1 += energy_mid_points[
-                                expanded_det_bin0.energy_index]
-                            energy_2 += energy_mid_points[
-                                expanded_det_bin1.energy_index]
+                            energy_1 += float(energy_mid_points[
+                                expanded_det_bin0.energy_index])
+                            energy_2 += float(energy_mid_points[
+                                expanded_det_bin1.energy_index])
                             if print_events:
                                 print(event)
                                 print(


### PR DESCRIPTION
## Changes in this pull request

- fix floating point precision issues when summing energies of many events

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

- fixes https://github.com/ETSInitiative/PETSIRD/issues/141

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following:

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
