### PR TITLE
Use python-m pip in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ set shell := ['bash', '-ceuo', 'pipefail']
     cd cpp/build && cmake --build .
 
 @build-python: generate
-    pip install --editable ./python
+    python -m pip install --editable ./python
 
 @build: build-cpp build-python
 


### PR DESCRIPTION
Fixes problems when the wrong `pip` (i.e. not the one matching your  `python`) is first in the path.

Fixes #143 