### PR TITLE
fix get_detection_efficiency python helper

### DIFF
--- a/python/petsird/helpers/__init__.py
+++ b/python/petsird/helpers/__init__.py
@@ -87,16 +87,19 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
                              type_of_module_pair: petsird.TypeOfModulePair,
                              event: petsird.CoincidenceEvent) -> float:
     """Compute the detection efficiency for a coincidence event"""
-    eff = 1
+    if scanner.detection_efficiencies is None:
+        # should never happen really, but this way, we don't crash.
+        return 1.
+
+    eff = 1.
 
     # per detection_bin efficiencies
-    if scanner.detection_efficiencies is not None:
+    detection_bin_efficiencies = scanner.detection_efficiencies.detection_bin_efficiencies
+    if detection_bin_efficiencies is not None:
         detection_bin_efficiencies0 = (
-            scanner.detection_efficiencies.detection_bin_efficiencies[
-                type_of_module_pair[0]])
+            detection_bin_efficiencies[type_of_module_pair[0]])
         detection_bin_efficiencies1 = (
-            scanner.detection_efficiencies.detection_bin_efficiencies[
-                type_of_module_pair[1]])
+            detection_bin_efficiencies[type_of_module_pair[1]])
         eff *= (detection_bin_efficiencies0[event.detection_bins[0]] *
                 detection_bin_efficiencies1[event.detection_bins[1]])
         if eff == 0:


### PR DESCRIPTION
Check if `detection_bin_efficiencies` is present, before we use  it. (We were checking `detection_efficiencies` instead)

Fixes #145 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
