### PR TITLE
use different variable name in draw_BowShape for PolyCollection

### DIFF
--- a/python/petsird/helpers/plot_scanner.py
+++ b/python/petsird/helpers/plot_scanner.py
@@ -23,7 +23,10 @@ def draw_BoxShape(ax, box: petsird.BoxShape) -> None:
         [vertices[j] for j in [1, 2, 6, 5]],
         [vertices[j] for j in [4, 7, 3, 0]],
     ]
-    box_poly = Poly3DCollection(edges, alpha=0.25, linewidths=1, edgecolors="r")
+    box_poly = Poly3DCollection(edges,
+                                alpha=0.25,
+                                linewidths=1,
+                                edgecolors="r")
     ax.add_collection3d(box_poly)
 
 

--- a/python/petsird/helpers/plot_scanner.py
+++ b/python/petsird/helpers/plot_scanner.py
@@ -23,8 +23,8 @@ def draw_BoxShape(ax, box: petsird.BoxShape) -> None:
         [vertices[j] for j in [1, 2, 6, 5]],
         [vertices[j] for j in [4, 7, 3, 0]],
     ]
-    box = Poly3DCollection(edges, alpha=0.25, linewidths=1, edgecolors="r")
-    ax.add_collection3d(box)
+    box_poly = Poly3DCollection(edges, alpha=0.25, linewidths=1, edgecolors="r")
+    ax.add_collection3d(box_poly)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes in this pull request

- `box` is used as input argument and then overwritten with different type
- use different variable name in draw_BowShape for PolyCollection
- otherwise typechecker gets confused

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following:

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
