### PR TITLE
move location of C++ generated files to generated/petsird and better CMake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,5 +15,5 @@ if(CCACHE_PROGRAM)
   message(STATUS "ccache found, so we will use it.")
 endif()
 
-add_subdirectory(generated)
+add_subdirectory(generated/petsird)
 add_subdirectory(helpers)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,5 +15,14 @@ if(CCACHE_PROGRAM)
   message(STATUS "ccache found, so we will use it.")
 endif()
 
+# assume that yardl was run with the following in the _package.yml
+#   sourcesOutputDir: ../cpp/generated/petsird
+
 add_subdirectory(generated/petsird)
+# create a petsird library target
+# Currently it is just empty, but allows creating target properties which are transitive
+add_library(petsird)
+target_link_libraries(petsird PUBLIC petsird_generated)
+target_include_directories(petsird PUBLIC "${PROJECT_SOURCE_DIR}/generated")
+
 add_subdirectory(helpers)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -17,3 +17,18 @@ The C++ code shows writing to and reading from an HDF5 file
 2. Run the generator: `./petsird_generator test.h5`
 3. Run the analyzer: `./petsird_analysis test.h5`
 4. You can inspect the HDF5 file by running `h5dump test.h5`
+
+## Using this is a library
+
+Currently, we do not install files yet. You therefore need to do something
+like
+```cmake
+set(PETSIRD_dir ../PETSIRD/cpp/) # or wherever
+add_subdirectory(${PETSIRD_dir} PETSIRD)
+
+# only uses petsird
+add_executable(your_executable PUBLIC STIR_PETSIRD_convertor.cpp petsird)
+
+# also uses helpers
+add_library(your_lib PUBLIC petsird_helpers)
+```

--- a/cpp/helpers/CMakeLists.txt
+++ b/cpp/helpers/CMakeLists.txt
@@ -1,12 +1,13 @@
+find_package(xtensor-blas REQUIRED)
+
+# create a petsird_helpers library target
+# Currently it is just empty, but allows creating target properties which are transitive
+add_library(petsird_helpers INTERFACE)
+target_link_libraries(petsird_helpers INTERFACE petsird xtensor-blas)
+target_include_directories(petsird_helpers INTERFACE "${PROJECT_SOURCE_DIR}/helpers/include")
 
 add_executable(petsird_generator petsird_generator.cpp)
-target_link_libraries(petsird_generator petsird_generated)
-target_include_directories(petsird_generator PRIVATE "${PROJECT_SOURCE_DIR}/helpers/include")
-# needed for generated PETSIRD files
-target_include_directories(petsird_generator PRIVATE "${PROJECT_SOURCE_DIR}/generated")
+target_link_libraries(petsird_generator petsird_helpers)
 
 add_executable(petsird_analysis petsird_analysis.cpp)
-target_link_libraries(petsird_analysis petsird_generated)
-target_include_directories(petsird_analysis PRIVATE "${PROJECT_SOURCE_DIR}/helpers/include")
-# needed for generated PETSIRD files
-target_include_directories(petsird_analysis PRIVATE "${PROJECT_SOURCE_DIR}/generated")
+target_link_libraries(petsird_analysis petsird_helpers)

--- a/cpp/helpers/CMakeLists.txt
+++ b/cpp/helpers/CMakeLists.txt
@@ -3,10 +3,10 @@ add_executable(petsird_generator petsird_generator.cpp)
 target_link_libraries(petsird_generator petsird_generated)
 target_include_directories(petsird_generator PRIVATE "${PROJECT_SOURCE_DIR}/helpers/include")
 # needed for generated PETSIRD files
-target_include_directories(petsird_generator PRIVATE "${PROJECT_SOURCE_DIR}/")
+target_include_directories(petsird_generator PRIVATE "${PROJECT_SOURCE_DIR}/generated")
 
 add_executable(petsird_analysis petsird_analysis.cpp)
 target_link_libraries(petsird_analysis petsird_generated)
 target_include_directories(petsird_analysis PRIVATE "${PROJECT_SOURCE_DIR}/helpers/include")
 # needed for generated PETSIRD files
-target_include_directories(petsird_analysis PRIVATE "${PROJECT_SOURCE_DIR}/")
+target_include_directories(petsird_analysis PRIVATE "${PROJECT_SOURCE_DIR}/generated")

--- a/cpp/helpers/include/petsird_helpers.h
+++ b/cpp/helpers/include/petsird_helpers.h
@@ -6,7 +6,7 @@
 #ifndef __petsird_helpers_h__
 #define __petsird_helpers_h__
 
-#include "generated/types.h"
+#include "petsird/types.h"
 #include <array>
 
 namespace petsird_helpers

--- a/cpp/helpers/include/petsird_helpers/create.h
+++ b/cpp/helpers/include/petsird_helpers/create.h
@@ -7,7 +7,7 @@
 #ifndef __petsird_helpers_create_h__
 #define __petsird_helpers_create_h__
 
-#include "generated/types.h"
+#include "petsird/types.h"
 #include <array>
 
 namespace petsird_helpers

--- a/cpp/helpers/include/petsird_helpers/geometry.h
+++ b/cpp/helpers/include/petsird_helpers/geometry.h
@@ -11,7 +11,7 @@
 #include <xtensor/xio.hpp>
 #include <xtensor-blas/xlinalg.hpp>
 #include <vector>
-#include "generated/types.h"
+#include "petsird/types.h"
 #include "petsird_helpers.h"
 
 namespace petsird_helpers

--- a/cpp/helpers/petsird_analysis.cpp
+++ b/cpp/helpers/petsird_analysis.cpp
@@ -9,10 +9,10 @@
 #define USE_HDF5
 
 #ifdef USE_HDF5
-#  include "generated/hdf5/protocols.h"
+#  include "petsird/hdf5/protocols.h"
 using petsird::hdf5::PETSIRDReader;
 #else
-#  include "generated/binary/protocols.h"
+#  include "petsird/binary/protocols.h"
 using petsird::binary::PETSIRDReader;
 #endif
 #include "petsird_helpers.h"

--- a/cpp/helpers/petsird_generator.cpp
+++ b/cpp/helpers/petsird_generator.cpp
@@ -14,10 +14,10 @@
 #define USE_HDF5
 
 #ifdef USE_HDF5
-#  include "generated/hdf5/protocols.h"
+#  include "petsird/hdf5/protocols.h"
 using petsird::hdf5::PETSIRDWriter;
 #else
-#  include "generated/binary/protocols.h"
+#  include "petsird/binary/protocols.h"
 using petsird::binary::PETSIRDWriter;
 #endif
 

--- a/model/_package.yml
+++ b/model/_package.yml
@@ -1,7 +1,7 @@
 namespace: PETSIRD
 
 cpp:
-  sourcesOutputDir: ../cpp/generated
+  sourcesOutputDir: ../cpp/generated/petsird
 
 python:
   outputDir: ../python


### PR DESCRIPTION
- Moving the generated C++ files, together with an adaptation of our CMakeLists.txt
- Create `petsird` and `petsird_helpers` (interface) libraries that keep track of include paths and dependencies

This means that we use `#include "petsird/types.h"` as opposed to `#include "generated/petsird.h"`

WARNING: breaks backward compatibility!

## Related issues
Fixes #128
Fixes #162

[x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
