### PR TITLE
justfile: run CMake install and add variables for location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
     - flake8-debugger
     - flake8-isort
     - flake8-pyproject
-    - flake8-string-format
 - repo: https://github.com/google/yapf
   rev: v0.43.0
   hooks:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.12.0) # older would work, but could give warnings on policy CMP0074
 
-project(PETSIRD VERSION 0.9.0 LANGUAGES CXX)
+project(PETSIRD VERSION 0.9.1 LANGUAGES CXX)
 include(GNUInstallDirs)
 set(PETSIRD_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/PETSIRD-0.9")
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,9 +3,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.12.0) # older would work, but could give warnings on policy CMP0074
-include(GNUInstallDirs)
 
 project(PETSIRD VERSION 0.9.0 LANGUAGES CXX)
+include(GNUInstallDirs)
 set(PETSIRD_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/PETSIRD-0.9")
 
 include(CMakePackageConfigHelpers)

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - ninja>=1.11.0
   - nlohmann_json>=3.11.2
   - numpy>=1.24.3
+  - pip
   - pre-commit>=4.0.1
   - python>=3.11.3
   - shellcheck>=0.8.0

--- a/justfile
+++ b/justfile
@@ -1,22 +1,40 @@
 set shell := ['bash', '-ceuo', 'pipefail']
 
+cmake_install_prefix := "$CONDA_PREFIX"
+cmake_build_type := "Release"
+cmake_build_dir := "cpp/build"
+
 @default: build
 
-@configure:
-    mkdir -p cpp/build; \
-    cd cpp/build; \
-    cmake -GNinja ..
+@help:
+    echo 'Usage: "just [cmake_install_prefix=<CMAKE_INSTALL_PREFIX>] [cmake_build_dir=<BUILD_DIR>] [cmake_build_type=Release]"'
+    echo 'The variables will be passed to CMake for the C++ build.'
+    echo 'Defaults:'
+    echo "  cmake_install_prefix=\$CONDA_PREFIX (which is currently set to \"$CONDA_PREFIX\")"
+    echo '  cmake_build_type=Release'
+    echo '  cmake_build_dir=cpp/build (this is relative to the PETSIRD folder)'
+    echo 'Run "just --summary" for possible recipes (default recipe is "build")'
+
+@configure: generate
+    cmake -GNinja -S cpp -B {{cmake_build_dir}} \
+      -DCMAKE_BUILD_TYPE:BOOL={{cmake_build_type}} \
+      -DCMAKE_INSTALL_PREFIX:PATH={{cmake_install_prefix}}
 
 @ensure-configured:
-    if [ ! -f cpp/build/CMakeCache.txt ]; then \
-        just configure; \
+    # Need to repeat variables here, as we do another call to "just"
+    if [ ! -f {{cmake_build_dir}}/CMakeCache.txt ]; then \
+      just cmake_install_prefix={{cmake_install_prefix}} \
+        cmake_build_type={{cmake_build_type}} cmake_build_dir={{cmake_build_dir}} \
+        configure; \
     fi
-
+    
 @generate:
     cd model && yardl generate
 
 @build-cpp: generate ensure-configured
-    cd cpp/build && cmake --build .
+    cd {{cmake_build_dir}} && \
+    cmake --build . --config {{cmake_build_type}} && \
+    cmake --install .
 
 @build-python: generate
     python -m pip install --editable ./python
@@ -27,7 +45,7 @@ set shell := ['bash', '-ceuo', 'pipefail']
 
 @run-cpp: build-cpp
     #!/usr/bin/env bash
-    cd cpp/build/helpers
+    cd {{cmake_build_dir}}/helpers
     ./petsird_generator testdata.petsird
     ./petsird_analysis testdata.petsird
     rm -f testdata.petsird

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ cmake_build_dir := "cpp/build"
         cmake_build_type={{cmake_build_type}} cmake_build_dir={{cmake_build_dir}} \
         configure; \
     fi
-    
+
 @generate:
     cd model && yardl generate
 


### PR DESCRIPTION
This makes it easier to build/install C++ files somewhere else. e.g.
```
just cmake_install_prefix=/tmp/petsird cmake_build_dir=cpp/build3
```