### PR TITLE
GantryMovementTimeBlock: movement per module-type

### DIFF
--- a/model/DetectorInformation.yml
+++ b/model/DetectorInformation.yml
@@ -28,16 +28,19 @@ DetectorModule: !record
 # A list of identical modules at different locations
 ReplicatedDetectorModule: ReplicatedObject< DetectorModule >
 
-# Full definition of the geometry of the scanner, consisting of
-# one of more types of modules replicated in space and (optional) other structures (e.g. side-shielding)
+# Full definition of the geometry of the scanner.
+# A PETSIRD scanner is built hierarchically. It consists of
+# one or more ReplicatedDetectorModules, each of which is potentially moving independently
+# (see GantryMovementTimeBlock), and (optional) other structures (e.g. side-shielding).
+# While most clinical scanners have only one type of DetectorModule, some
+# would have different types, e.g. for scanners with phoswich detectors, high resolution inserts, etc.
 ScannerGeometry: !record
   fields:
-    # list of different types of replicated modules
-    # While most current clinical scanners have only one type of DetectorModule, some
-    # would have different types, e.g. for scanners with phoswich detector, high resolution inserts, etc.
+    # list of different types of (replicated) modules
     # Constraint: numberOfModuleTypes > 0
     replicatedModules: ReplicatedDetectorModule*
     # shielding etc
+    # These nonDetectingVolumes cannot move w.r.t. the reference position.
     nonDetectingVolumes: GenericSolidVolume*?
   computedFields:
     numberOfModuleTypes: size(replicatedModules)

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -141,14 +141,12 @@ ExternalSignalTimeBlock: !record
    # Note for triggers, this field is to be ignored
    signalValues: float*
 
-# A time-block indicating that the patient bed moved from the reference position.
+# A time-block indicating that the patient bed moved from the PET reference position.
 # Note that the bed is supposed to be stationary during the time-block, and until
 # a new BedMovementTimeBlock occurs. Continuous movement therefore needs to be approximated
 # by a series of steps.
 # TODO encode an initial bed position in the header, or require that the first time-block is a
 # BedMovementTimeBlock?
-# TODO specify if bed movement is encoded in PET reference or "overall" reference
-# (see ScannerInformation.gantryAlignment)
 BedMovementTimeBlock: !record
   fields:
     # time interval for this time block
@@ -168,7 +166,7 @@ GantryMovementTimeBlock: !record
   fields:
     # time interval for this time block
     timeInterval: TimeInterval
-    # Tranforms encoding movement from the coordinates specified in the ScannerGeometry to
+    # Tranforms encode movement from the coordinates specified in the ScannerGeometry to
     # the PET scanner reference position. To go to the overall reference position, follow
     # with ScannerInformation.gantryAlignment.
     # One transformation per module-type.

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -141,17 +141,39 @@ ExternalSignalTimeBlock: !record
    # Note for triggers, this field is to be ignored
    signalValues: float*
 
+# A time-block indicating that the patient bed moved from the reference position.
+# Note that the bed is supposed to be stationary during the time-block, and until
+# a new BedMovementTimeBlock occurs. Continuous movement therefore needs to be approximated
+# by a series of steps.
+# TODO encode an initial bed position in the header, or require that the first time-block is a
+# BedMovementTimeBlock?
+# TODO specify if bed movement is encoded in PET reference or "overall" reference
+# (see ScannerInformation.gantryAlignment)
 BedMovementTimeBlock: !record
   fields:
     # time interval for this time block
     timeInterval: TimeInterval
     transform: RigidTransformation
 
+# A time-block indicating that the gantry/gantries moved from the PET reference position.
+# We allow that each "module-type" (see ScannerGeometry) is on a different gantry, i.e.
+# could move independently. In practice, several module-types can move together (or not at all).
+# Nevertheless, a transform needs to be given for each module_type.
+#
+# Note that the gantry/gantries are supposed to be stationary during the time-block, and until
+# a new GantryMovementTimeBlock occurs. Continuous movement therefore needs to be approximated
+# by a series of steps.
+# See also ScannerInformation.gantryAlignment.
 GantryMovementTimeBlock: !record
   fields:
     # time interval for this time block
     timeInterval: TimeInterval
-    transform: RigidTransformation
+    # Tranforms encoding movement from the coordinates specified in the ScannerGeometry to
+    # the PET scanner reference position. To go to the overall reference position, follow
+    # with ScannerInformation.gantryAlignment.
+    # One transformation per module-type.
+    # Constraint: size(transforms) == ScannerGeometry.numberOfModuleTypes()
+    transforms: RigidTransformation*
 
 # A time block that stores the dead-time information for the given interval
 # Dead-time is encoded as "alive_time_fraction", i.e. 1 - dead_time_fraction


### PR DESCRIPTION
WARNING: backwards incompatible

Fixes #169

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
