### PR TITLE
Use detection bin symmetry in efficiencies and alive-time

### DIFF
--- a/cpp/helpers/include/petsird_helpers.h
+++ b/cpp/helpers/include/petsird_helpers.h
@@ -14,6 +14,25 @@ namespace petsird_helpers
 
 using namespace petsird;
 
+//! check if 2 detections are ordered
+/*!
+   PETSIRD requires that coincidence events are ordered. This function checks that
+   (type_of_module_pair[0] > type_of_module_pair[1]) || (detectionBin1 >= detectionBin2)
+*/
+inline bool
+are_detections_ordered(const TypeOfModulePair& type_of_module_pair, const DetectionBin& detection_bin_1,
+                       const DetectionBin& detection_bin_2)
+{
+  return (type_of_module_pair[0] > type_of_module_pair[1]) || (detection_bin_1 >= detection_bin_2);
+}
+
+//! check if a coincidence event is ordered
+inline bool
+are_detections_ordered(const TypeOfModulePair& type_of_module_pair, const CoincidenceEvent& event)
+{
+  return are_detections_ordered(type_of_module_pair, event.detection_bins[0], event.detection_bins[1]);
+}
+
 // TODO remove?
 inline std::size_t
 get_num_det_els(const ScannerInformation& scanner, const TypeOfModule& type_of_module)
@@ -104,7 +123,7 @@ get_detection_efficiency(const ScannerInformation& scanner, const TypeOfModulePa
                          const DetectionBin& detection_bin_1, const DetectionBin& detection_bin_2,
                          bool with_calibration_factor = true)
 {
-  assert(type_of_module_pair[0] <= type_of_module_pair[1]);
+  assert(are_detections_ordered(type_of_module_pair, detection_bin_1, detection_bin_2));
 
   float eff = with_calibration_factor ? scanner.detection_efficiencies.calibration_factor : 1.0F;
   const auto& detection_bin_efficiencies = scanner.detection_efficiencies.detection_bin_efficiencies;

--- a/cpp/helpers/include/petsird_helpers.h
+++ b/cpp/helpers/include/petsird_helpers.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2024, 2025 University College London
+  Copyright (C) 2024-2026 University College London
 
   SPDX-License-Identifier: Apache-2.0
 */
@@ -104,38 +104,44 @@ get_detection_efficiency(const ScannerInformation& scanner, const TypeOfModulePa
                          const DetectionBin& detection_bin_1, const DetectionBin& detection_bin_2,
                          bool with_calibration_factor = true)
 {
+  assert(type_of_module_pair[0] <= type_of_module_pair[1]);
+
   float eff = with_calibration_factor ? scanner.detection_efficiencies.calibration_factor : 1.0F;
   const auto& detection_bin_efficiencies = scanner.detection_efficiencies.detection_bin_efficiencies;
-  if (detection_bin_efficiencies)
+  if (!detection_bin_efficiencies.empty())
     {
-      eff *= ((*detection_bin_efficiencies)[type_of_module_pair[0]](detection_bin_1)
-              * (*detection_bin_efficiencies)[type_of_module_pair[1]](detection_bin_2));
+      eff *= (detection_bin_efficiencies[type_of_module_pair[0]][detection_bin_1]
+              * detection_bin_efficiencies[type_of_module_pair[1]][detection_bin_2]);
       if (eff == 0.F)
         return 0.F;
     }
   const auto& module_pair_efficiencies_vectors = scanner.detection_efficiencies.module_pair_efficiencies_vectors;
-  if (module_pair_efficiencies_vectors)
+  if (!module_pair_efficiencies_vectors.empty())
     {
-      assert(scanner.detection_efficiencies.module_pair_sgidlut);
+      // TODO
+      // assert(scanner.detection_efficiencies.module_pair_sgidlut.size() == number_of_modules_types);
       const auto& module_pair_SGID_LUT
-          = (*scanner.detection_efficiencies.module_pair_sgidlut)[type_of_module_pair[0]][type_of_module_pair[1]];
+          = scanner.detection_efficiencies.module_pair_sgidlut[type_of_module_pair[0]][type_of_module_pair[1]];
 
       const auto expanded_det_bin0 = expand_detection_bin(scanner, type_of_module_pair[0], detection_bin_1);
       const auto expanded_det_bin1 = expand_detection_bin(scanner, type_of_module_pair[1], detection_bin_2);
-      const int SGID = module_pair_SGID_LUT(expanded_det_bin0.module_index, expanded_det_bin1.module_index);
+      assert(expanded_det_bin0.module_index < module_pair_SGID_LUT.size());
+      assert(expanded_det_bin1.module_index < module_pair_SGID_LUT[expanded_det_bin0.module_index].size());
+
+      const int SGID = module_pair_SGID_LUT[expanded_det_bin0.module_index][expanded_det_bin1.module_index];
       if (SGID < 0)
         {
           return 0.;
         }
 
       const auto& module_pair_efficiencies
-          = (*module_pair_efficiencies_vectors)[type_of_module_pair[0]][type_of_module_pair[1]][SGID];
-      assert(module_pair_efficiencies.sgid == static_cast<unsigned>(SGID));
-      const auto& num_en0 = scanner.event_energy_bin_edges[type_of_module_pair[0]].NumberOfBins();
-      const auto& num_en1 = scanner.event_energy_bin_edges[type_of_module_pair[1]].NumberOfBins();
+          = module_pair_efficiencies_vectors[type_of_module_pair[0]][type_of_module_pair[1]][SGID];
+      assert(module_pair_efficiencies.sgid == SGID);
+      const auto num_en0 = scanner.event_energy_bin_edges[type_of_module_pair[0]].NumberOfBins();
+      const auto num_en1 = scanner.event_energy_bin_edges[type_of_module_pair[1]].NumberOfBins();
       // TODO create helper for next calculation
-      eff *= module_pair_efficiencies.values(expanded_det_bin0.element_index * num_en0 + expanded_det_bin0.energy_index,
-                                             expanded_det_bin1.element_index * num_en1 + expanded_det_bin1.energy_index);
+      eff *= module_pair_efficiencies.values[expanded_det_bin0.element_index * num_en0 + expanded_det_bin0.energy_index]
+                                            [expanded_det_bin1.element_index * num_en1 + expanded_det_bin1.energy_index];
     }
   return eff;
 }

--- a/cpp/helpers/include/petsird_helpers/create.h
+++ b/cpp/helpers/include/petsird_helpers/create.h
@@ -27,7 +27,7 @@ construct_vector(std::size_t size)
 
 //! Helper function to create a std::vector<std::vector<T>> as a 2D array of size (size0, size1)
 template <typename T>
-std::vector<std::vector<T>>
+petsird::RectangularMatrix<T>
 construct_rectangular_matrix(std::size_t size0, std::size_t size1)
 {
   std::vector<std::vector<T>> v(size0);
@@ -41,7 +41,7 @@ construct_rectangular_matrix(std::size_t size0, std::size_t size1)
 //! Helper function to create a std::vector<std::vector<T>> as a 2D array of size (size, row-number)
 /*! Result is a "matrix" such that for `matrix[i][j]`, `i>=j`. */
 template <typename T>
-std::vector<std::vector<T>>
+petsird::LowerTriangularMatrix<T>
 construct_lower_triangular_matrix(std::size_t size)
 {
   std::vector<std::vector<T>> v(size);
@@ -55,7 +55,7 @@ construct_lower_triangular_matrix(std::size_t size)
 //! Helper function to create a std::vector<std::vector<T>> as a lower-triangular matrix of size size0 or a matrix size (size0,
 //! size1)
 template <typename T>
-std::vector<std::vector<T>>
+petsird::LowerTriangularOrRectangularMatrix<T>
 construct_lower_triangular_or_rectangular_matrix(std::size_t size0, std::size_t size1, bool is_lower_triangular)
 {
   return is_lower_triangular ? construct_lower_triangular_matrix<T>(size0) : construct_rectangular_matrix<T>(size0, size1);

--- a/cpp/helpers/include/petsird_helpers/create.h
+++ b/cpp/helpers/include/petsird_helpers/create.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2025 University College London
+  Copyright (C) 2025-2026 University College London
 
   SPDX-License-Identifier: Apache-2.0
 */
@@ -16,7 +16,7 @@ namespace create
 {
 
 //! Helper function to create a std::vector<T>
-/*! This function is added to have a 1D analogue construct_2D_nested_vector() */
+/*! This function is added to have a 1D analogue construct_rectangular_matrix() */
 template <typename T>
 std::vector<T>
 construct_vector(std::size_t size)
@@ -28,7 +28,7 @@ construct_vector(std::size_t size)
 //! Helper function to create a std::vector<std::vector<T>> as a 2D array of size (size0, size1)
 template <typename T>
 std::vector<std::vector<T>>
-construct_2D_nested_vector(std::size_t size0, std::size_t size1)
+construct_rectangular_matrix(std::size_t size0, std::size_t size1)
 {
   std::vector<std::vector<T>> v(size0);
   for (auto& one_of_them : v)
@@ -38,7 +38,30 @@ construct_2D_nested_vector(std::size_t size0, std::size_t size1)
   return v;
 }
 
-//! Set  various structures to have the correct size for the given num_types_of_modules
+//! Helper function to create a std::vector<std::vector<T>> as a 2D array of size (size, row-number)
+/*! Result is a "matrix" such that for `matrix[i][j]`, `i>=j`. */
+template <typename T>
+std::vector<std::vector<T>>
+construct_lower_triangular_matrix(std::size_t size)
+{
+  std::vector<std::vector<T>> v(size);
+  for (std::size_t i = 0; i < size; ++i)
+    {
+      v[i].resize(i + 1);
+    }
+  return v;
+}
+
+//! Helper function to create a std::vector<std::vector<T>> as a lower-triangular matrix of size size0 or a matrix size (size0,
+//! size1)
+template <typename T>
+std::vector<std::vector<T>>
+construct_lower_triangular_or_rectangular_matrix(std::size_t size0, std::size_t size1, bool is_lower_triangular)
+{
+  return is_lower_triangular ? construct_lower_triangular_matrix<T>(size0) : construct_rectangular_matrix<T>(size0, size1);
+}
+
+//! Set various structures to have the correct size for the given num_types_of_modules
 /*!
   This will set scanner.tof_bin_edges, scanner.tof_resolution,
   scanner.event_energy_bin_edges, scanner.energy_resolution_at_511, and
@@ -57,8 +80,8 @@ inline void
 initialize_scanner_information_dimensions(petsird::ScannerInformation& scanner, const std::size_t num_module_types,
                                           bool allocate_detection_bin_efficiencies, bool allocate_module_pair_efficiencies)
 {
-  scanner.tof_bin_edges = construct_2D_nested_vector<petsird::BinEdges>(num_module_types, num_module_types);
-  scanner.tof_resolution = construct_2D_nested_vector<float>(num_module_types, num_module_types);
+  scanner.tof_bin_edges = construct_rectangular_matrix<petsird::BinEdges>(num_module_types, num_module_types); // TODO lower
+  scanner.tof_resolution = construct_rectangular_matrix<float>(num_module_types, num_module_types);            // TODO lower
   scanner.event_energy_bin_edges = construct_vector<petsird::BinEdges>(num_module_types);
   scanner.energy_resolution_at_511 = construct_vector<float>(num_module_types);
 
@@ -74,9 +97,9 @@ initialize_scanner_information_dimensions(petsird::ScannerInformation& scanner, 
   if (allocate_module_pair_efficiencies)
     {
       scanner.detection_efficiencies.module_pair_sgidlut
-          = construct_2D_nested_vector<petsird::ModulePairSGIDLUT>(num_module_types, num_module_types);
+          = construct_lower_triangular_matrix<petsird::ModulePairSGIDLUT>(num_module_types);
       scanner.detection_efficiencies.module_pair_efficiencies_vectors
-          = construct_2D_nested_vector<petsird::ModulePairEfficienciesVector>(num_module_types, num_module_types);
+          = construct_lower_triangular_matrix<petsird::ModulePairEfficienciesVector>(num_module_types);
     }
 }
 

--- a/cpp/helpers/petsird_analysis.cpp
+++ b/cpp/helpers/petsird_analysis.cpp
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2022-2023 Microsoft Corporation
-  Copyright (C) 2023-2025 University College London
+  Copyright (C) 2023-2026 University College London
 
   SPDX-License-Identifier: Apache-2.0
 */
@@ -184,7 +184,7 @@ main(int argc, char const* argv[])
           for (unsigned mtype0 = 0; mtype0 < num_module_types; ++mtype0)
             {
               const auto& energy_mid_points0 = all_energy_mid_points[mtype0];
-              for (unsigned mtype1 = 0; mtype1 < num_module_types; ++mtype1)
+              for (unsigned mtype1 = 0; mtype1 <= mtype0; ++mtype1)
                 {
                   const petsird::TypeOfModulePair mtype_pair{ mtype0, mtype1 };
                   const auto& energy_mid_points1 = all_energy_mid_points[mtype1];

--- a/cpp/helpers/petsird_generator.cpp
+++ b/cpp/helpers/petsird_generator.cpp
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2022-2023 Microsoft Corporation
-  Copyright (C) 2023-2025 University College London
+  Copyright (C) 2023-2026 University College London
 
   SPDX-License-Identifier: Apache-2.0
 */
@@ -116,9 +116,11 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
   // use some non-physical value for the calibration factor
   scanner.detection_efficiencies.calibration_factor = 42.F;
 
+#ifndef NDEBUG
   const auto num_module_types = scanner.scanner_geometry.NumberOfModuleTypes();
   // only 1 type of module in the current scanner
   assert(num_module_types == 1);
+#endif
   const petsird::TypeOfModule type_of_module{ 0 };
   const auto num_detection_bins = petsird_helpers::get_num_detection_bins(scanner, type_of_module);
 
@@ -126,15 +128,15 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
   const auto num_event_energy_bins = event_energy_bin_edges.NumberOfBins();
 
   // set all detection_bin_efficiencies to 1 in this example
-  if (scanner.detection_efficiencies.detection_bin_efficiencies)
+  if (!scanner.detection_efficiencies.detection_bin_efficiencies.empty())
     {
-      auto& bin_effs = (*scanner.detection_efficiencies.detection_bin_efficiencies)[type_of_module];
-      yardl::resize(bin_effs, { num_detection_bins });
+      auto& bin_effs = scanner.detection_efficiencies.detection_bin_efficiencies[type_of_module];
+      bin_effs.resize(num_detection_bins);
       std::fill(begin(bin_effs), end(bin_effs), 1.F);
     }
 
   // check if the caller wants to have module-pair stuff. If not, return.
-  if (!scanner.detection_efficiencies.module_pair_efficiencies_vectors)
+  if (scanner.detection_efficiencies.module_pair_efficiencies_vectors.empty())
     return;
 
   const auto& rep_module = scanner.scanner_geometry.replicated_modules[type_of_module];
@@ -151,11 +153,15 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
   // SGID = z1 + NZ * (z2 + NZ * abs(a2 - a1) - 1)
   constexpr auto NZ = NUM_MODULES_ALONG_AXIS;
 
-  auto& module_pair_SGID_LUT = (*scanner.detection_efficiencies.module_pair_sgidlut)[type_of_module][type_of_module];
-  module_pair_SGID_LUT = yardl::NDArray<int, 2>({ num_modules, num_modules });
+  auto& module_pair_SGID_LUT = scanner.detection_efficiencies.module_pair_sgidlut[type_of_module][type_of_module];
+  module_pair_SGID_LUT
+      = petsird_helpers::create::construct_lower_triangular_or_rectangular_matrix<petsird::SGID>(num_modules, num_modules, true);
+  // note: if using different module types, we need construct_lower_triangular_or_rectangular_matrix<petsird::SGID>(num_modules1,
+  // num_modules2, false)
+
   for (unsigned int mod1 = 0; mod1 < num_modules; ++mod1)
     {
-      for (unsigned int mod2 = 0; mod2 < num_modules; ++mod2)
+      for (unsigned int mod2 = 0; mod2 <= mod1; ++mod2) // note: if using different module types, we need mod2 < num_modules2
         {
           const auto z1 = mod1 % NZ;
           const auto a1 = mod1 / NZ;
@@ -163,21 +169,21 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
           const auto a2 = mod2 / NZ;
           if (a1 == a2)
             {
-              module_pair_SGID_LUT(mod1, mod2) = -1;
+              module_pair_SGID_LUT[mod1][mod2] = -1;
             }
           else
             {
-              module_pair_SGID_LUT(mod1, mod2) = z1 + NZ * (z2 + NZ * (std::abs(int(a2) - int(a1)) - 1));
+              module_pair_SGID_LUT[mod1][mod2] = z1 + NZ * (z2 + NZ * (std::abs(int(a2) - int(a1)) - 1));
             }
+          assert(module_pair_SGID_LUT[mod1][mod2] < num_SGIDs);
         }
     }
-  // assert(module_pair_SGID_LUT).max() == num_SGIDs - 1);
 
   // initialise module_pair_efficiencies
   auto& module_pair_efficiencies_vector
-      = (*scanner.detection_efficiencies.module_pair_efficiencies_vectors)[type_of_module][type_of_module];
-  // assign an empty vector first, and reserve correct size
-  module_pair_efficiencies_vector = petsird::ModulePairEfficienciesVector();
+      = scanner.detection_efficiencies.module_pair_efficiencies_vectors[type_of_module][type_of_module];
+  // make sure we have an empty vector first, and reserve correct size
+  module_pair_efficiencies_vector.resize(0);
   module_pair_efficiencies_vector.reserve(num_SGIDs);
 
   const auto& detecting_elements = rep_module.object.detecting_elements;
@@ -188,9 +194,16 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
       // extract first module_pair for this SGID. However, as this currently unused, it is commented out
       // const auto& module_pair = *std::find(module_pair_SGID_LUT.begin(), module_pair_SGID_LUT.end(), SGID);
       petsird::ModulePairEfficiencies module_pair_efficiencies;
-      module_pair_efficiencies.values = yardl::NDArray<float, 2>({ num_detection_bins_in_module, num_detection_bins_in_module });
+      module_pair_efficiencies.values = petsird_helpers::create::construct_lower_triangular_or_rectangular_matrix<float>(
+          num_detection_bins_in_module, num_detection_bins_in_module, type_of_module == type_of_module);
+      // note: somewhat funny line above in the hope it's clear how to modify it for different module types
+
       // give some (non-physical) value
-      module_pair_efficiencies.values.fill(SGID);
+      for (auto& effs_for_mod1 : module_pair_efficiencies.values)
+        for (auto& eff : effs_for_mod1)
+          {
+            eff = SGID;
+          }
       module_pair_efficiencies.sgid = SGID;
       module_pair_efficiencies_vector.emplace_back(module_pair_efficiencies);
       assert(module_pair_efficiencies_vector.size() == unsigned(SGID + 1));
@@ -286,6 +299,8 @@ get_events(const petsird::Header& header, std::size_t num_events)
   std::vector<petsird::CoincidenceEvent> events;
   events.reserve(num_events);
   const petsird::TypeOfModulePair type_of_module_pair{ 0, 0 };
+  const auto type_of_module0 = type_of_module_pair[0];
+  const auto type_of_module1 = type_of_module_pair[1];
   const auto num_modules0 = header.scanner.scanner_geometry.replicated_modules[type_of_module_pair[0]].transforms.size();
   const auto num_detecting_elements0
       = header.scanner.scanner_geometry.replicated_modules[type_of_module_pair[0]].object.detecting_elements.transforms.size();
@@ -311,8 +326,10 @@ get_events(const petsird::Header& header, std::size_t num_events)
           assert(expanded_detection_bin0
                  == petsird_helpers::expand_detection_bin(header.scanner, type_of_module_pair[0], e.detection_bins[0]));
 
-          // short-cut to directly generate a random detection bin
-          e.detection_bins[1] = get_random_uint(num_bins1);
+          // short-cut to directly generate a random detection bin.
+          // Note: we need the events to be ordered
+          const auto max_bin1 = type_of_module0 == type_of_module1 ? e.detection_bins[0] : num_bins1;
+          e.detection_bins[1] = get_random_uint(max_bin1);
 
           if (petsird_helpers::get_detection_efficiency(header.scanner, type_of_module_pair, e) > 0)
             {

--- a/cpp/helpers/petsird_generator.cpp
+++ b/cpp/helpers/petsird_generator.cpp
@@ -194,9 +194,8 @@ set_detection_efficiencies(petsird::ScannerInformation& scanner)
       // extract first module_pair for this SGID. However, as this currently unused, it is commented out
       // const auto& module_pair = *std::find(module_pair_SGID_LUT.begin(), module_pair_SGID_LUT.end(), SGID);
       petsird::ModulePairEfficiencies module_pair_efficiencies;
-      module_pair_efficiencies.values = petsird_helpers::create::construct_lower_triangular_or_rectangular_matrix<float>(
-          num_detection_bins_in_module, num_detection_bins_in_module, type_of_module == type_of_module);
-      // note: somewhat funny line above in the hope it's clear how to modify it for different module types
+      module_pair_efficiencies.values = petsird_helpers::create::construct_rectangular_matrix<float>(
+          num_detection_bins_in_module, num_detection_bins_in_module);
 
       // give some (non-physical) value
       for (auto& effs_for_mod1 : module_pair_efficiencies.values)

--- a/model/BasicTypes.yml
+++ b/model/BasicTypes.yml
@@ -1,0 +1,16 @@
+# A "template" type to denote a rectangular 2D array
+# represented as a vector of vectors.
+RectangularMatrix<T>: T**
+
+# A "template" type to denote a lower-triangular 2D array
+# represented as a vector of vectors.
+# Sizes have to be such that for matrix[i][j], j<=i
+LowerTriangularMatrix<T>: T**
+
+# A "template" type to denote a lower-triangular or rectangular 2D array
+# represented as a vector of vectors.
+# If triangular, sizes have to be such that for matrix[i][j], j<=i
+#
+# This type is used to represent data that are lower-triangular for equal
+# module-types, but rectangular otherwise.
+LowerTriangularOrRectangularMatrix<T>: T**

--- a/model/DetectionEfficiencies.yml
+++ b/model/DetectionEfficiencies.yml
@@ -6,27 +6,45 @@
 # SGIDs are used to efficiently encode module-pair efficiencies etc.
 SGID: uint
 
-# Detection efficiencies for every DetectionBin if a particular type of module
-# Constraint: size == number of all possible unique DetectionBins
+# A "template" type to denote a lower-triangular 2D array
+# represented as a vector of vectors.
+# Sizes have to be such that for matrix[i][j], j<=i
+LowerTriangularMatrix<T>: T**
+
+# A "template" type to denote a lower-triangular or rectangular 2D array
+# represented as a vector of vectors.
+# If triangular, sizes have to be such that for matrix[i][j], j<=i
+#
+# This type is used to represent data that are lower-triangular for equal
+# module-types, but rectangular otherwise.
+LowerTriangularOrRectangularMatrix<T>: T**
+
+# Detection efficiencies for every DetectionBin if a particular type of module.
+# Constraint: size == number of all possible unique DetectionBins of that module-type
 DetectionBinEfficiencies: float[detectionBin]
 
 # Detection efficiency for two detection bins in a pair of modules.
 # This is one component (often called "geometric") of the detection efficiency model.
 # Note that "detection bin" includes energy windows (if any) for the modules.
+# Note that the modules can be of different types.
 ModulePairEfficiencies: !record
   fields:
     # Detection efficiency for a pair of detection bins
-    # detectionBin1 and detectionBin2 run from 0 up to the number of detections_bins in each module,
-    values: float[detectionBin1, detectionBin2]
+    # values[detectionBin1][detectionBin2] with detectionBin1 ranging from 0 up to the number of
+    # detectionsBins in the first module.
+    # The second index runs from 0 to either detectionBin1 (if the 2 modules are of the same type)
+    # or to the number of detectionBins in the second module.
+    values: LowerTriangularOrRectangularMatrix<float>
     # Symmetry Group Identifier (SGID)
     # This should be a number between 0 and numberOfSGIDs-1
     sgid: SGID
 
 
-# Lookup table for SGIDs
+# Lookup table for SGIDs for a pair of modules (which can be of different type)
 # For every module pair (of specific types), give the SGID. If -1, the module-pair is not in coincidence.
 # Values run from -1 ... (numberOfSGIDs-1)
-ModulePairSGIDLUT: int[moduleIndex1, moduleIndex2]
+# indexed by moduleIndex1, moduleIndex2
+ModulePairSGIDLUT: LowerTriangularOrRectangularMatrix<int>
 
 # List of ModulePairEfficiencies, one for each SGID
 ModulePairEfficienciesVector: ModulePairEfficiencies*
@@ -45,14 +63,15 @@ ModulePairEfficienciesVector: ModulePairEfficiencies*
 # 0. obtain module-types
 # 1. find module_index for each detection_bin
 # 2. find detection_bin "inside" each module
-# 3. SGID = modulePairSGIDLUT[type_of_module1][type_of_module2][module_index1, module_index2]
+# 3. SGID = modulePairSGIDLUT[type_of_module1][type_of_module2][module_index1][module_index2]
 # 4. if (SGID < 0) return 0
 # 5. module_pair_efficiencies = modulePairEfficienciesVector[type_of_module1][type_of_module2][SGID]
-# 6. return calibrationFactor
+# 6. return
+#       calibrationFactor
 #       * detectionBinEfficiencies[type_of_module1](detection_bin1) * detectionBinEfficiencies[type_of_module2](detection_bin2)
-#       * module_pair_efficiencies[detection_bin_in_module1, detection_bin_in_module2]
+#       * module_pair_efficiencies[detection_bin_in_module1][detection_bin_in_module2]
 #
-# If either of the components is not present, its value is considered to be 1.
+# If any of the components is not present (or size 0), its value is considered to be 1.
 #
 # The calibrationFactor is defined in terms of measured/expected "true unscattered" coincidences.
 # Moreover, it is (in principle) defined in terms of an idealised measurement of large uniform source.
@@ -64,7 +83,7 @@ ModulePairEfficienciesVector: ModulePairEfficiencies*
 # This definition has the effect that for a given pair of detection_bins, we should have
 #   mean_precorrected_true_coincidences =
 #     detection_effiency * line_integral(number_of_positron_annihilations_in_source_as_estimated_from_dose_calibrator)
-#   (with the precorrection taking into scatter and attenuation)
+#   (with the precorrection taking scatter and attenuation into account).
 #
 # Note that computing a detection efficiency for a triple coincidence is left to the user.
 DetectionEfficiencies: !record
@@ -75,24 +94,23 @@ DetectionEfficiencies: !record
     calibrationFactor: float
     # List of detection efficiencies for every detection bin (one for each module-type).
     # Constraint: size(detectionBinEfficiencies) == ScannerGeometry.numberOfModuleTypes()
-    detectionBinEfficiencies: DetectionBinEfficiencies*?
-    # Nested list of lookup tables for SGIDs, one for each module-type pair.
+    detectionBinEfficiencies: DetectionBinEfficiencies*
+    # Nested list of lookup tables for SGIDs, one for each module-type pair (type_of_module2<=type_of_module1).
     # Also indicates if coincidences between a module-pair are recorded.
-    modulePairSGIDLUT: ModulePairSGIDLUT**?
-    # Nested list of all modulePairEfficienciesVectors (one for each module-type pair)
+    modulePairSGIDLUT: LowerTriangularMatrix<ModulePairSGIDLUT>
+    # Nested list of all modulePairEfficienciesVectors (one for each module-type pair with type_of_module2<=type_of_module1)
     # Constraint: size(modulePairEfficienciesVectors[type_of_module1][type_of_module2]) == max(modulePairSGIDLUT[type_of_module1][type_of_module2]) + 1
-    modulePairEfficienciesVectors: ModulePairEfficienciesVector**?
+    modulePairEfficienciesVectors: LowerTriangularMatrix<ModulePairEfficienciesVector>
 
 # Type for alive-time fractions for singles
 # See AliveTimeFractions
-# Constraint: size == number of all possible DetectionBins (for a specific type_of_module)
+# Constraint: size() == number of all possible DetectionBins (for the specific type_of_module)
 SinglesAliveTimeFractions: float[detectionBin]
 
 # Type for coincidence alive time fractions array for 2 modules in coincidence
-# See AliveTimeFractions
+# See AliveTimeFractions and restrictions on size.
 ModuleCoincidenceAliveTimeFractions: !array
-      items: float
-      dimensions: [moduleId0, moduleId1]
+      items: LowerTriangularOrRectangularMatrix<float>
 
 # Type for alive-time fraction information
 # (1 means no dead-time, 0 means no detected counts)
@@ -106,10 +124,16 @@ ModuleCoincidenceAliveTimeFractions: !array
 AliveTimeFractions: !record
   fields:
     # List of singles alive-time fractions (one for each type of module)
+    # Constraint: size(singlesAliveTimeFractions) == ScannerGeometry.numberOfModuleTypes()
     singlesAliveTimeFractions: SinglesAliveTimeFractions*
     # Nested list of all-time fractions for 2 modules in coincidence.
-    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2], 0) == total number of modules of type 1
-    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2], 1) == total number of modules of types 2
-    # Constraint: moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1, mod2] ==
+    # Note that in principle, we have
+    # moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1, mod2] ==
     #   moduleCoincidenceAliveTimeFractions[type_of_module2][type_of_module1][mod2, mod1]
-    moduleCoincidenceAliveTimeFractions: ModuleCoincidenceAliveTimeFractions**?
+    # Therefore only the "lower half" is stored (type_of_module1>=type_of_module2,
+    # and a LowerTriangular array if type_of_module1==type_of_module2).
+    # Constraint: size(moduleCoincidenceAliveTimeFractions) == ScannerGeometry.numberOfModuleTypes()
+    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2]) == (number of modules of type 1)
+    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1]) == 
+    #      if (type_of_module1 == type_of_module2): (mod1+1) else (number of modules of type 2)
+    moduleCoincidenceAliveTimeFractions: LowerTriangularMatrix<ModuleCoincidenceAliveTimeFractions>

--- a/model/DetectionEfficiencies.yml
+++ b/model/DetectionEfficiencies.yml
@@ -4,7 +4,8 @@
 # by such a symmetry often have the same geometric detection efficiencies. PETSIRD
 # calls this a "symmetry group" (SG). Each SG had a unique identifier (SGID).
 # SGIDs are used to efficiently encode module-pair efficiencies etc.
-SGID: uint
+# Note that a negative SGID is used to denote that a module-pair is not in coincidence.
+SGID: int
 
 # A "template" type to denote a lower-triangular 2D array
 # represented as a vector of vectors.
@@ -21,7 +22,7 @@ LowerTriangularOrRectangularMatrix<T>: T**
 
 # Detection efficiencies for every DetectionBin if a particular type of module.
 # Constraint: size == number of all possible unique DetectionBins of that module-type
-DetectionBinEfficiencies: float[detectionBin]
+DetectionBinEfficiencies: float*
 
 # Detection efficiency for two detection bins in a pair of modules.
 # This is one component (often called "geometric") of the detection efficiency model.
@@ -134,6 +135,6 @@ AliveTimeFractions: !record
     # and a LowerTriangular array if type_of_module1==type_of_module2).
     # Constraint: size(moduleCoincidenceAliveTimeFractions) == ScannerGeometry.numberOfModuleTypes()
     # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2]) == (number of modules of type 1)
-    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1]) == 
+    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1]) ==
     #      if (type_of_module1 == type_of_module2): (mod1+1) else (number of modules of type 2)
     moduleCoincidenceAliveTimeFractions: LowerTriangularMatrix<ModuleCoincidenceAliveTimeFractions>

--- a/model/DetectionEfficiencies.yml
+++ b/model/DetectionEfficiencies.yml
@@ -110,7 +110,7 @@ SinglesAliveTimeFractions: float[detectionBin]
 
 # Type for coincidence alive time fractions array for 2 modules in coincidence
 # See AliveTimeFractions and restrictions on size.
-ModuleCoincidenceAliveTimeFractions: !array
+ModulePairAliveTimeFractions: !array
       items: LowerTriangularOrRectangularMatrix<float>
 
 # Type for alive-time fraction information
@@ -121,7 +121,7 @@ ModuleCoincidenceAliveTimeFractions: !array
 # aliveTimeFraction((type_of_module1, detectionBin1), (type_of_module2, detectionBin2)) =
 #   singlesAliveTimeFractions[type_of_module1](detectionBin1) *
 #   singlesAliveTimeFractions[type_of_module2](detectionBin2) *
-#   moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][module(detectionBin1), module(detectionBin2)]
+#   modulePairAliveTimeFractions[type_of_module1][type_of_module2][module(detectionBin1), module(detectionBin2)]
 AliveTimeFractions: !record
   fields:
     # List of singles alive-time fractions (one for each type of module)
@@ -129,12 +129,12 @@ AliveTimeFractions: !record
     singlesAliveTimeFractions: SinglesAliveTimeFractions*
     # Nested list of all-time fractions for 2 modules in coincidence.
     # Note that in principle, we have
-    # moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1, mod2] ==
-    #   moduleCoincidenceAliveTimeFractions[type_of_module2][type_of_module1][mod2, mod1]
+    # modulePairAliveTimeFractions[type_of_module1][type_of_module2][mod1, mod2] ==
+    #   modulePairAliveTimeFractions[type_of_module2][type_of_module1][mod2, mod1]
     # Therefore only the "lower half" is stored (type_of_module1>=type_of_module2,
     # and a LowerTriangular array if type_of_module1==type_of_module2).
-    # Constraint: size(moduleCoincidenceAliveTimeFractions) == ScannerGeometry.numberOfModuleTypes()
-    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2]) == (number of modules of type 1)
-    # Constraint: size(moduleCoincidenceAliveTimeFractions[type_of_module1][type_of_module2][mod1]) ==
+    # Constraint: size(modulePairAliveTimeFractions) == ScannerGeometry.numberOfModuleTypes()
+    # Constraint: size(modulePairAliveTimeFractions[type_of_module1][type_of_module2]) == (number of modules of type 1)
+    # Constraint: size(modulePairAliveTimeFractions[type_of_module1][type_of_module2][mod1]) ==
     #      if (type_of_module1 == type_of_module2): (mod1+1) else (number of modules of type 2)
-    moduleCoincidenceAliveTimeFractions: LowerTriangularMatrix<ModuleCoincidenceAliveTimeFractions>
+    modulePairAliveTimeFractions: LowerTriangularMatrix<ModulePairAliveTimeFractions>

--- a/model/DetectionEfficiencies.yml
+++ b/model/DetectionEfficiencies.yml
@@ -7,6 +7,10 @@
 # Note that a negative SGID is used to denote that a module-pair is not in coincidence.
 SGID: int
 
+# A "template" type to denote a rectangular 2D array
+# represented as a vector of vectors.
+RectangularMatrix<T>: T**
+
 # A "template" type to denote a lower-triangular 2D array
 # represented as a vector of vectors.
 # Sizes have to be such that for matrix[i][j], j<=i
@@ -31,11 +35,9 @@ DetectionBinEfficiencies: float*
 ModulePairEfficiencies: !record
   fields:
     # Detection efficiency for a pair of detection bins
-    # values[detectionBin1][detectionBin2] with detectionBin1 ranging from 0 up to the number of
-    # detectionsBins in the first module.
-    # The second index runs from 0 to either detectionBin1 (if the 2 modules are of the same type)
-    # or to the number of detectionBins in the second module.
-    values: LowerTriangularOrRectangularMatrix<float>
+    # values[detectionBin1][detectionBin2] with detectionBins ranging from 0 up to the number of
+    # detectionsBins in the each module.
+    values: RectangularMatrix<float>
     # Symmetry Group Identifier (SGID)
     # This should be a number between 0 and numberOfSGIDs-1
     sgid: SGID
@@ -44,7 +46,7 @@ ModulePairEfficiencies: !record
 # Lookup table for SGIDs for a pair of modules (which can be of different type)
 # For every module pair (of specific types), give the SGID. If -1, the module-pair is not in coincidence.
 # Values run from -1 ... (numberOfSGIDs-1)
-# indexed by moduleIndex1, moduleIndex2
+# It is indexed by moduleIndex1, moduleIndex2 and lower-triangular if the module-types are the same.
 ModulePairSGIDLUT: LowerTriangularOrRectangularMatrix<int>
 
 # List of ModulePairEfficiencies, one for each SGID

--- a/model/DetectionEfficiencies.yml
+++ b/model/DetectionEfficiencies.yml
@@ -7,23 +7,6 @@
 # Note that a negative SGID is used to denote that a module-pair is not in coincidence.
 SGID: int
 
-# A "template" type to denote a rectangular 2D array
-# represented as a vector of vectors.
-RectangularMatrix<T>: T**
-
-# A "template" type to denote a lower-triangular 2D array
-# represented as a vector of vectors.
-# Sizes have to be such that for matrix[i][j], j<=i
-LowerTriangularMatrix<T>: T**
-
-# A "template" type to denote a lower-triangular or rectangular 2D array
-# represented as a vector of vectors.
-# If triangular, sizes have to be such that for matrix[i][j], j<=i
-#
-# This type is used to represent data that are lower-triangular for equal
-# module-types, but rectangular otherwise.
-LowerTriangularOrRectangularMatrix<T>: T**
-
 # Detection efficiencies for every DetectionBin if a particular type of module.
 # Constraint: size == number of all possible unique DetectionBins of that module-type
 DetectionBinEfficiencies: float*

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -70,14 +70,12 @@ EventTimeBlock: !record
    # given in the `CoincidenceEvent` is in a module of the first type, use
    #  promptEvents[typeOfModule1][typeOfModule2]
    # Note that the ListOfCoincidenceEvents could be empty for a particular module-pair.
-   # Note that in principle, this nested vector could be made "upper diagonal",
-   # but this is currently not enforced. Therefore, to check all coincidences between two
-   # different types of modules, a user will have to check two lists, i.e. also
-   #  promptEvents[typeOfModule2][typeOfModule1]
+   # Note that events have to be ordered, i.e.
+   #    (typeOfModule1 > typeOfModule2) || (detectionBin1 >= detectionBin2)
    # Constraint: (size(promptEvents) > 0) == ScannerInformation.promptEventsAreStored
    # Constraint: (size(promptEvents) == 0) || (size(promptsEvents) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(promptEvents) == 0) || (size(promptsEvents[*]) == ScannerInformation.numberOfModuleTypes)
-   promptEvents: ListOfCoincidenceEvents**
+   # Constraint: (size(promptEvents) == 0) || (size(promptsEvents[typeOfModule1]) == typeOfModule1 + 1)
+   promptEvents: LowerTriangularMatrix<ListOfCoincidenceEvents>
 
    # nested vector with lists of delayed coincidences in this time block
    # To get the list of delayeds for 2 types of modules, use
@@ -85,28 +83,30 @@ EventTimeBlock: !record
    # See promptEvents for more information.
    # Constraint: (size(delayedEvents) > 0) == ScannerInformation.delayedCoincidencesAreStored
    # Constraint: (size(delayedEvents) == 0) || (size(delayedEvents) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(delayedEvents) == 0) || (size(delayedEvents[*]) == ScannerInformation.numberOfModuleTypes)
-   delayedEvents: ListOfCoincidenceEvents**
+   # Constraint: (size(delayedEvents) == 0) || (size(delayedEvents[typeOfModule1]) == typeOfModule1 + 1)
+   delayedEvents: LowerTriangularMatrix<ListOfCoincidenceEvents>
 
    # nested vector with lists of triple coincidences in this time block
    # To get the list of triples for 3 types of modules, use
    #  tripleEvents[typeOfModule1][typeOfModule2][typeOfModule3]
+   # Note that events have to be ordered using lexicographical ordering in (typeOfModule_i, detectionBin_i).
    # See promptEvents for more information.
    # Constraint: (size(tripleEvents) > 0) == ScannerInformation.tripleEventsAreStored
    # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[*]) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[*][*]) == ScannerInformation.numberOfModuleTypes)
+   # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[typeOfModule1]) == typeOfModule1 + 1)
+   # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[type1][type2]) == type2 + 1)
    tripleEvents: ListOfTripleEvents***
 
    # nested vector with lists of quadruple coincidences in this time block
    # To get the list of quadruples for 4 types of modules, use
    #  quadrupleEvents[typeOfModule1][typeOfModule2][typeOfModule3][typeOfModule4]
+   # Note that events have to be ordered using lexicographical ordering in (typeOfModule_i, detectionBin_i).
    # See promptEvents for more information.
    # Constraint: (size(quadrupleEvents) > 0) == ScannerInformation.quadrupleEventsAreStored
    # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[*]) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[*][*]) == ScannerInformation.numberOfModuleTypes)
-   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[*][*][*]) == ScannerInformation.numberOfModuleTypes)
+   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[typeOfModule1]) == typeOfModule1 + 1)
+   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[type1][type2]) == type2 + 1)
+   # Constraint: (size(quadrupleEvents) == 0) || (size(quadrupleEvents[type1][type2][type3]) == type3 + 1)
    quadrupleEvents: ListOfQuadrupleEvents****
 
 ExternalSignalTypeEnum: !enum

--- a/model/ScannerInformation.yml
+++ b/model/ScannerInformation.yml
@@ -97,6 +97,7 @@ ScannerInformation: !record
     #
     # This is a nested vector with elements of type BinEdges, i.e. it specifies the edges for every module-pair
     # (actually pair of module-types).
+    # (One element for each module-type pair with type_of_module2<=type_of_module1)
     # To get the tof bin edges for 2 types of modules, use
     #  tofBinEdges[typeOfModule1][typeOfModule2]
     #
@@ -107,8 +108,8 @@ ScannerInformation: !record
     # TODO: this currently assumes equal size for each TOF bin, but some scanners "stretch" TOF bins depending on length of LOR
     # Constraint: this 2D array has to be symmetric.
     # Constraint: size(tofBinEdges) == size(ScannerGeometry.replicatedModules)
-    # Constraint: size(tofBinEdges[*]) == size(ScannerGeometry.replicatedModules)
-    tofBinEdges: BinEdges**
+    # Constraint: size(tofBinEdges[typeOfModule1]) == typeOfModule1 + 1
+    tofBinEdges: LowerTriangularMatrix<BinEdges>
 
     # TOF resolution aka CTR (as FWHM) in mm
     # To get the Coincidence Timing Resolution (CTR) in mm for 2 types of modules, use
@@ -117,8 +118,8 @@ ScannerInformation: !record
     #
     # Constraint: this 2D array has to be symmetric.
     # Constraint: size(tofResolution) == size(ScannerGeometry.replicatedModules)
-    # Constraint: size(tofResolution[*]) == size(ScannerGeometry.replicatedModules)
-    tofResolution: float**
+    # Constraint: size(tofResolution[typeOfModule1]) == typeOfModule1 + 1
+    tofResolution: LowerTriangularMatrix<float>
 
     # Edge information (in keV) for energy windows used for coincidences, triples etc
     #

--- a/python/petsird/helpers/__init__.py
+++ b/python/petsird/helpers/__init__.py
@@ -11,6 +11,18 @@ import typing
 import petsird
 
 
+def are_detections_ordered(type_of_module_pair: petsird.TypeOfModulePair,
+                           detection_bin_1: petsird.DetectionBin,
+                           detection_bin_2: petsird.DetectionBin) -> bool:
+    """check if 2 detections are ordered
+
+    PETSIRD requires that coincidence events are ordered. This function checks that
+    (type_of_module_pair[0] > type_of_module_pair[1]) || (detectionBin1 >= detectionBin2)
+    """
+    return (type_of_module_pair[0]
+            > type_of_module_pair[1]) or (detection_bin_1 >= detection_bin_2)
+
+
 # TODO remove?
 def get_num_det_els(scanner: petsird.ScannerInformation,
                     type_of_module: petsird.TypeOfModule) -> int:
@@ -124,9 +136,8 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
         # should never happen really, but this way, we don't crash.
         return 1.
 
-    assert type_of_module_pair[0] >= type_of_module_pair[1]
-    assert (type_of_module_pair[0] != type_of_module_pair[1]
-            or detection_bin_1 >= detection_bin_2)
+    assert are_detections_ordered(type_of_module_pair, detection_bin_1,
+                                  detection_bin_2)
 
     eff = (scanner.detection_efficiencies.calibration_factor
            if with_calibration_factor else 1.)

--- a/python/petsird/helpers/__init__.py
+++ b/python/petsird/helpers/__init__.py
@@ -124,6 +124,10 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
         # should never happen really, but this way, we don't crash.
         return 1.
 
+    assert type_of_module_pair[0] >= type_of_module_pair[1]
+    assert (type_of_module_pair[0] != type_of_module_pair[1]
+            or detection_bin_1 >= detection_bin_2)
+
     eff = (scanner.detection_efficiencies.calibration_factor
            if with_calibration_factor else 1.)
 
@@ -143,7 +147,8 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
     module_pair_efficiencies_vectors = (
         scanner.detection_efficiencies.module_pair_efficiencies_vectors)
     if module_pair_efficiencies_vectors is not None:
-        module_pair_SGID_LUT = scanner.detection_efficiencies.module_pair_sgidlut
+        module_pair_SGID_LUT = scanner.detection_efficiencies.module_pair_sgidlut[
+            type_of_module_pair[0]][type_of_module_pair[1]]
         assert module_pair_SGID_LUT is not None
         expanded_det_bin0 = expand_detection_bin(scanner,
                                                  type_of_module_pair[0],
@@ -152,9 +157,12 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
                                                  type_of_module_pair[1],
                                                  detection_bin_2)
 
-        SGID = module_pair_SGID_LUT[type_of_module_pair[0]][
-            type_of_module_pair[1]][expanded_det_bin0.module_index,
-                                    expanded_det_bin1.module_index]
+        assert expanded_det_bin0.module_index < len(module_pair_SGID_LUT)
+        assert expanded_det_bin1.module_index < len(
+            module_pair_SGID_LUT[expanded_det_bin0.module_index])
+
+        SGID = module_pair_SGID_LUT[expanded_det_bin0.module_index][
+            expanded_det_bin1.module_index]
         if SGID < 0:
             return 0.
         module_pair_efficiencies = module_pair_efficiencies_vectors[
@@ -167,8 +175,8 @@ def get_detection_efficiency(scanner: petsird.ScannerInformation,
         # TODO create helper for next calculation
         eff *= module_pair_efficiencies.values[
             expanded_det_bin0.element_index * num_en0 +
-            expanded_det_bin0.energy_index,
-            expanded_det_bin1.element_index * num_en1 +
-            expanded_det_bin1.energy_index]
+            expanded_det_bin0.energy_index][expanded_det_bin1.element_index *
+                                            num_en1 +
+                                            expanded_det_bin1.energy_index]
 
     return eff

--- a/python/petsird/helpers/analysis.py
+++ b/python/petsird/helpers/analysis.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
               scanner.detection_efficiencies.calibration_factor)
         if scanner.detection_efficiencies.module_pair_sgidlut is not None:
             for type_of_module0 in range(num_module_types):
-                for type_of_module1 in range(num_module_types):
+                for type_of_module1 in range(type_of_module0 + 1):
                     print("------ Module type pair ", type_of_module0,
                           type_of_module1)
                     with np.printoptions(threshold=2000, linewidth=140):
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                 last_time = time_block.value.time_interval.stop
                 for mtype0 in range(num_module_types):
                     energy_mid_points0 = all_energy_mid_points[mtype0]
-                    for mtype1 in range(num_module_types):
+                    for mtype1 in range(mtype0 + 1):
                         energy_mid_points1 = all_energy_mid_points[mtype1]
                         mtype_pair = petsird.TypeOfModulePair((mtype0, mtype1))
 

--- a/python/petsird/helpers/create.py
+++ b/python/petsird/helpers/create.py
@@ -1,0 +1,119 @@
+"""
+Preliminary helpers for creating data structures for PETSIRD data
+"""
+
+#  Copyright (C) 2026 University College London
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import petsird
+
+
+def construct_vector(size: int, dtype: Any = float, value=None) -> list:
+    """Helper function to create a list of items of type dtype
+
+    Elements will be constructed via the default constructors, so you will still have
+    to fill in the actual values.
+    """
+    if value is None:
+        return [dtype() for i in range(size)]
+    else:
+        return [value for i in range(size)]
+
+
+def construct_rectangular_matrix(size0: int,
+                                 size1: int,
+                                 dtype: Any = float,
+                                 value: Any = None) -> list[list]:
+    """Helper function to create a list of lists of items of type dtype
+
+    The result is equivalent to a 2D array of size (size0, size1).
+
+    Elements will be constructed via the default constructors, so you will still have
+    to fill in the actual values.
+    """
+    return [
+        construct_vector(size1, dtype=dtype, value=value) for i in range(size0)
+    ]
+
+
+def construct_lower_triangular_matrix(size: int,
+                                      dtype: Any = float,
+                                      value: Any = None) -> list[list]:
+    """Helper function to create a nested vector equivalent to a lower-triangular matrix
+
+    Result is a 'matrix' where `matrix[i][j]` is only defined/stored for `i>=j`.
+
+    Elements will be constructed via the default constructors, so you will still have
+    to fill in the actual values.
+    """
+    return [
+        construct_vector(i + 1, dtype=dtype, value=value) for i in range(size)
+    ]
+
+
+def construct_lower_triangular_or_rectangular_matrix(
+        size0: int,
+        size1: int,
+        is_lower_triangular: bool,
+        dtype: Any = float,
+        value: Any = None) -> list[list]:
+    """Helper function to create a nested vector
+
+    The result is equivelent to either a lower-triangular matrix of size `size0`
+    or a matrix size `(size0,size1)`.
+
+    Elements will be constructed via the default constructors, so you will still have
+    to fill in the actual values.
+    """
+    return construct_lower_triangular_matrix(
+        size0, dtype=dtype,
+        value=value) if is_lower_triangular else construct_rectangular_matrix(
+            size0, size1, dtype=dtype, value=value)
+
+
+def initialize_scanner_information_dimensions(
+        scanner: petsird.ScannerInformation, num_module_types: int,
+        allocate_detection_bin_efficiencies: bool,
+        allocate_module_pair_efficiencies: bool) -> None:
+    """Set various structures to have the correct size for the given num_types_of_modules
+
+    This will set scanner.tof_bin_edges, scanner.tof_resolution,
+    scanner.event_energy_bin_edges, scanner.energy_resolution_at_511, and
+    and (optionally) scanner.detection_efficiencies.detection_bin_efficiencies,
+    scanner.detection_efficiencies.module_pair_sgidlut and
+    scanner.detection_efficiencies.module_pair_efficiencies_vectors
+    to (nested) vectors of the appropriate type and size.
+
+    Elements will be constructed via the default constructors, so you will still have
+    to fill in the actual values.
+
+    To prevent dramatic errors, the calibration_factor is set to 1, but this factor has
+    to be set correctly afterwards.
+    """
+    scanner.tof_bin_edges = construct_rectangular_matrix(
+        num_module_types, num_module_types, dtype=petsird.BinEdges)
+    scanner.tof_resolution = construct_rectangular_matrix(num_module_types,
+                                                          num_module_types,
+                                                          dtype=float)
+    scanner.event_energy_bin_edges = construct_vector(num_module_types,
+                                                      dtype=petsird.BinEdges)
+    scanner.energy_resolution_at_511 = construct_vector(num_module_types)
+
+    scanner.detection_efficiencies = petsird.DetectionEfficiencies()
+    # set this to 1 to avoid the case where the user forgets to set it
+    scanner.detection_efficiencies.calibration_factor = 1.
+
+    if allocate_detection_bin_efficiencies:
+        scanner.detection_efficiencies.detection_bin_efficiencies = construct_vector(
+            num_module_types, dtype=petsird.DetectionBinEfficiencies)
+
+    if allocate_module_pair_efficiencies:
+        scanner.detection_efficiencies.module_pair_sgidlut = (
+            construct_lower_triangular_matrix(num_module_types,
+                                              dtype=petsird.ModulePairSGIDLUT))
+        scanner.detection_efficiencies.module_pair_efficiencies_vectors = (
+            construct_lower_triangular_matrix(
+                num_module_types, dtype=petsird.ModulePairEfficienciesVector))

--- a/python/petsird/helpers/generator.py
+++ b/python/petsird/helpers/generator.py
@@ -1,11 +1,11 @@
 #  Copyright (C) 2022-2023 Microsoft Corporation
-#  Copyright (C) 2023-2025 University College London
+#  Copyright (C) 2023-2026 University College London
 #
 #  SPDX-License-Identifier: Apache-2.0
 """This is an example file how to create a PETSIRD file.
 
 It creates a demo scanner with 2 types of modules, and some random events.
-Efficiencies are also stores, although the values are meaningless.
+Efficiencies are also stored, although the values are meaningless.
 
 This code only serves as illustration on how to create a PETSIRD file, and
 will need serious adaption to be useful.
@@ -20,6 +20,9 @@ from typing import Iterable, List, Tuple
 import numpy
 import petsird
 from petsird.helpers import get_detection_efficiency, get_num_detection_bins
+from petsird.helpers.create import (
+    construct_lower_triangular_or_rectangular_matrix, construct_vector,
+    initialize_scanner_information_dimensions)
 
 
 @dataclass
@@ -51,36 +54,36 @@ class CylindricalBlocksInfo:
 # 2 examples, not very physical plausible/efficient.
 # We will build a scanner from both below.
 mtype0_def = CylindricalBlocksInfo(
-    radius=400,
-    crystal_length=(20, 4, 4),
+    radius=400.,
+    crystal_length=(20., 4., 4.),
     num_crystals_per_module=(2, 4, 7),
     num_modules_along_ring=20,
     num_modules_along_axis=2,
     arc=2 * math.pi,
-    start_angle=0,
+    start_angle=0.,
     module_spacing_along_axis=(7 + 24) *
     4.,  # (num_crystals_per_module[2] + 24) * crystal_length[2],
     number_of_tof_bins=11,
-    tof_resolution=9,
-    LLD=450,
-    ULD=650,
+    tof_resolution=9.,
+    LLD=450.,
+    ULD=650.,
     number_of_event_energy_bins=3,
     energy_resolution=0.1,
     material_id=1,
 )
 mtype1_def = CylindricalBlocksInfo(
-    radius=150,
-    crystal_length=(10, 2, 2),
+    radius=150.,
+    crystal_length=(10., 2., 2.),
     num_crystals_per_module=(1, 3, 30),
     num_modules_along_ring=15,
     num_modules_along_axis=1,
     arc=math.pi,
-    start_angle=0,
+    start_angle=0.,
     module_spacing_along_axis=0.,
     number_of_tof_bins=5,
     tof_resolution=6,
-    LLD=460,
-    ULD=640,
+    LLD=460.,
+    ULD=640.,
     number_of_event_energy_bins=1,
     energy_resolution=0.8,
     material_id=1,
@@ -88,7 +91,7 @@ mtype1_def = CylindricalBlocksInfo(
 # Some constants related to how many events we will generate etc
 NUMBER_OF_TIME_BLOCKS = 6
 NUMBER_OF_EVENTS = 1000
-COUNT_RATE = 500  # 1/ms
+COUNT_RATE = 500.  # 1/ms
 EVENT_TIME_BLOCK_DURATION = 1  # ms
 
 
@@ -188,30 +191,36 @@ def get_detection_bin_efficiencies(
     scanner: petsird.ScannerInformation,
     type_of_module: int,
     module_def: CylindricalBlocksInfo,
-) -> numpy.ndarray:
+) -> list:
     """return some (non-physical) detection bin efficiencies"""
     num_detection_bins = get_num_detection_bins(scanner, type_of_module)
-    detection_bin_efficiencies = numpy.ones((num_detection_bins),
-                                            dtype=numpy.float32)
+    detection_bin_efficiencies = construct_vector(num_detection_bins,
+                                                  dtype=float,
+                                                  value=1.)
     return detection_bin_efficiencies
 
 
-def create_empty_module_pair_SGID_LUT(scanner: petsird.ScannerInformation,
-                                      type_of_module0: int,
-                                      type_of_module1: int) -> numpy.ndarray:
+def create_empty_module_pair_SGID_LUT(
+        scanner: petsird.ScannerInformation, type_of_module0: int,
+        type_of_module1: int) -> petsird.ModulePairSGIDLUT:
     """return a LUT that says no modules are in coincidence"""
     num_modules0 = len(scanner.scanner_geometry.
                        replicated_modules[type_of_module0].transforms)
     num_modules1 = len(scanner.scanner_geometry.
                        replicated_modules[type_of_module1].transforms)
-    LUT = numpy.ndarray((num_modules0, num_modules1), dtype="int32")
-    LUT[:] = -1
+    LUT = construct_lower_triangular_or_rectangular_matrix(
+        num_modules0,
+        num_modules1,
+        type_of_module0 == type_of_module1,
+        dtype=int,
+        value=-1)
     return LUT
 
 
-def create_empty_module_pair_efficiencies(
-        scanner: petsird.ScannerInformation, type_of_module0: int,
-        type_of_module1: int) -> numpy.ndarray:
+def create_empty_module_pair_efficiencies(scanner: petsird.ScannerInformation,
+                                          type_of_module0: int,
+                                          type_of_module1: int,
+                                          value: float) -> list[list]:
     """return a 2d array (filled with 1) of the appropriate size"""
     rep_module = scanner.scanner_geometry.replicated_modules[type_of_module0]
     detecting_elements0 = rep_module.object.detecting_elements
@@ -223,13 +232,14 @@ def create_empty_module_pair_efficiencies(
     num_det_els_in_module1 = len(detecting_elements1.transforms)
     event_energy_bin_edges1 = scanner.event_energy_bin_edges[type_of_module1]
     num_event_energy_bins1 = event_energy_bin_edges1.number_of_bins()
-    module_pair_efficiencies = numpy.ones(
-        (
-            num_det_els_in_module0 * num_event_energy_bins0,
-            num_det_els_in_module1 * num_event_energy_bins1,
-        ),
-        dtype=numpy.float32,
-    )
+    size0 = num_det_els_in_module0 * num_event_energy_bins0
+    size1 = num_det_els_in_module1 * num_event_energy_bins1
+    module_pair_efficiencies = construct_lower_triangular_or_rectangular_matrix(
+        size0,
+        size1,
+        type_of_module0 == type_of_module1,
+        dtype=float,
+        value=value)
     return module_pair_efficiencies
 
 
@@ -237,7 +247,7 @@ def get_module_pair_efficiencies_one_module_type(
     scanner: petsird.ScannerInformation,
     type_of_module: int,
     module_def: CylindricalBlocksInfo,
-) -> Tuple[numpy.ndarray, List[petsird.ModulePairEfficiencies]]:
+) -> Tuple[petsird.ModulePairSGIDLUT, list[list]]:
     """return detection efficiencies for a module-pair of the same type
 
     The function returns a tuple with module_pair_SGID_LUT,
@@ -269,33 +279,31 @@ def get_module_pair_efficiencies_one_module_type(
     module_pair_SGID_LUT = create_empty_module_pair_SGID_LUT(
         scanner, type_of_module, type_of_module)
     for mod1 in range(num_modules):
-        for mod2 in range(num_modules):
+        for mod2 in range(mod1 + 1):
             z1 = mod1 % NZ
             a1 = mod1 // NZ
             z2 = mod2 % NZ
             a2 = mod2 // NZ
             if a1 == a2:
-                module_pair_SGID_LUT[mod1, mod2] = -1
+                module_pair_SGID_LUT[mod1][mod2] = -1
             else:
-                module_pair_SGID_LUT[mod1,
-                                     mod2] = z1 + NZ * (z2 + NZ *
-                                                        (abs(a2 - a1) - 1))
+                module_pair_SGID_LUT[mod1][mod2] = z1 + NZ * (
+                    z2 + NZ * (abs(a2 - a1) - 1))
 
     # print("SGID LUT:\n", module_pair_SGID_LUT, file=sys.stderr)
-    assert numpy.max(module_pair_SGID_LUT) == num_SGIDs - 1
+    assert max([max(r) for r in module_pair_SGID_LUT]) == num_SGIDs - 1
     module_pair_efficiencies_vector = []
 
-    module_pair_efficiencies = create_empty_module_pair_efficiencies(
-        scanner, type_of_module, type_of_module)
     for SGID in range(num_SGIDs):
         # Extract first module_pair for this SGID. However, as this is
         # currently unused, it is commented out
         # module_pair = numpy.argwhere(module_pair_SGID_LUT == SGID)[0]
         # print(module_pair, file=sys.stderr)
         # give some (non-physical) value
+        module_pair_efficiencies = create_empty_module_pair_efficiencies(
+            scanner, type_of_module, type_of_module, value=float(SGID + 1))
         module_pair_efficiencies_vector.append(
-            petsird.ModulePairEfficiencies(values=module_pair_efficiencies *
-                                           SGID,
+            petsird.ModulePairEfficiencies(values=module_pair_efficiencies,
                                            sgid=SGID))
         assert len(module_pair_efficiencies_vector) == SGID + 1
 
@@ -308,7 +316,7 @@ def get_module_pair_efficiencies_two_module_types(
     type_of_module1: int,
     module_def0: CylindricalBlocksInfo,
     module_def1: CylindricalBlocksInfo,
-) -> Tuple[numpy.ndarray, List[petsird.ModulePairEfficiencies]]:
+) -> Tuple[petsird.ModulePairSGIDLUT, List[petsird.ModulePairEfficiencies]]:
     """return detection efficiencies for a module-pair of different types
 
     The function returns a tuple with module_pair_SGID_LUT,
@@ -320,16 +328,19 @@ def get_module_pair_efficiencies_two_module_types(
     """
     LUT = create_empty_module_pair_SGID_LUT(scanner, type_of_module0,
                                             type_of_module1)
-    module_pair_efficiencies = create_empty_module_pair_efficiencies(
-        scanner, type_of_module0, type_of_module1)
     SGID = 0  # first SGID needs to be 0
     module_pair_efficiencies_vector = []
-    for m0 in range(LUT.shape[0]):
-        for m1 in range(LUT.shape[1]):
-            LUT[m0, m1] = SGID
+    for m0 in range(len(LUT)):
+        for m1 in range(len(LUT[m0])):
+            LUT[m0][m1] = SGID
             # using nonsensical values for the following
+            module_pair_efficiencies = create_empty_module_pair_efficiencies(
+                scanner,
+                type_of_module0,
+                type_of_module1,
+                value=float(SGID + 1))
             petsird_module_pair_efficiencies = petsird.ModulePairEfficiencies(
-                values=module_pair_efficiencies * SGID, sgid=SGID)
+                values=module_pair_efficiencies, sgid=SGID)
             module_pair_efficiencies_vector.append(
                 petsird_module_pair_efficiencies)
             SGID += 1
@@ -337,28 +348,21 @@ def get_module_pair_efficiencies_two_module_types(
     return LUT, module_pair_efficiencies_vector
 
 
-def get_detection_efficiencies(
+def fill_detection_efficiencies(
     scanner: petsird.ScannerInformation,
     module_defs: Iterable[CylindricalBlocksInfo],
-) -> petsird.DetectionEfficiencies:
-    """return some (non-physical) detection efficiencies"""
+):
+    """fill-in some (non-physical) detection efficiencies"""
 
     # use some non-physical value for the calibration factor
-    calibration_factor = 42.
+    scanner.detection_efficiencies.calibration_factor = 42.
     num_types_of_modules = scanner.scanner_geometry.number_of_module_types()
-    # single-level list for detection_bin_efficiencies
-    all_detection_bin_efficiencies = []
-    # double-level list for module_pair things
-    all_LUTs = []
-    all_module_pair_efficiencies_vectors = []
     for mtype0 in range(num_types_of_modules):
         detection_bin_efficiencies = get_detection_bin_efficiencies(
             scanner, mtype0, module_defs[mtype0])
-        all_detection_bin_efficiencies.append(detection_bin_efficiencies)
-        # single-level lists for the information at the current mtype0
-        LUTs0 = []
-        module_pair_efficiencies_vectors0 = []
-        for mtype1 in range(num_types_of_modules):
+        scanner.detection_efficiencies.detection_bin_efficiencies[
+            mtype0] = detection_bin_efficiencies
+        for mtype1 in range(mtype0 + 1):
             # construct information
             if (mtype0 == mtype1):
                 (LUT, module_pair_efficiencies_vector
@@ -369,21 +373,12 @@ def get_detection_efficiencies(
                  ) = get_module_pair_efficiencies_two_module_types(
                      scanner, mtype0, mtype1, module_defs[mtype0],
                      module_defs[mtype1])
-            # append to "row" lists
-            LUTs0.append(LUT)
-            module_pair_efficiencies_vectors0.append(
-                module_pair_efficiencies_vector)
-        # append "rows" to double-level lists
-        all_LUTs.append(LUTs0)
-        all_module_pair_efficiencies_vectors.append(
-            module_pair_efficiencies_vectors0)
-
-    return petsird.DetectionEfficiencies(
-        calibration_factor=calibration_factor,
-        detection_bin_efficiencies=all_detection_bin_efficiencies,
-        module_pair_sgidlut=all_LUTs,
-        module_pair_efficiencies_vectors=all_module_pair_efficiencies_vectors,
-    )
+            scanner.detection_efficiencies.module_pair_sgidlut[mtype0][
+                mtype1] = LUT
+            scanner.detection_efficiencies.module_pair_efficiencies_vectors[
+                mtype0][mtype1] = module_pair_efficiencies_vector
+    # print(scanner.detection_efficiencies.module_pair_sgidlut, file=stderr)
+    # print(scanner.detection_efficiencies.module_pair_efficiencies_vectors, file=stderr)
 
 
 def get_scanner_info(
@@ -394,13 +389,23 @@ def get_scanner_info(
 
     # TODO scanner_info.bulk_materials
 
-    # TOF info (in mm)
-    allTofBinEdges = []
-    allTofResolutions = []
+    # We need energy bin info before being able to construct the detection
+    # efficiencies, so we first construct a scanner without the efficiencies
+    scanner = petsird.ScannerInformation(model_name="PETSIRD_TEST",
+                                         scanner_geometry=scanner_geometry)
+
+    num_types_of_modules = scanner.scanner_geometry.number_of_module_types()
+    # Pre-allocate various structures to have the correct size for num_types_of_modules
+    # (We will still have to set descent values into each of these.)
+    initialize_scanner_information_dimensions(
+        scanner,
+        num_types_of_modules,
+        allocate_detection_bin_efficiencies=True,
+        allocate_module_pair_efficiencies=True)
+
     for mtype0, m_def0 in enumerate(module_defs):
-        allTofBinEdgesThisModuleType = []
-        allTofResolutionsThisModuleType = []
-        for mtype1, m_def1 in enumerate(module_defs):
+        for mtype1 in range(num_types_of_modules):  # TODO range(mtype0 + 1):
+            m_def1 = module_defs[mtype1]
             # In this example, we determine the coincidence window from the radii.
             # Obviously, a real scanner likely will do something else.
             max_distance = m_def0.radius + m_def1.radius
@@ -413,42 +418,27 @@ def get_scanner_info(
             else:
                 # In this example, no TOF information between different module-types
                 num_tof_bins = 1
-                allTofResolutionsThisModuleType.append(1000)  # in mm
+                tof_resolution_this_pair = 1000  # in mm
+            scanner.tof_resolution[mtype0][mtype1] = tof_resolution_this_pair
             tofBinEdgesThisPair = petsird.BinEdges(edges=numpy.linspace(
                 -max_distance, max_distance, num_tof_bins +
                 1, dtype="float32"))
-            allTofBinEdgesThisModuleType.append(tofBinEdgesThisPair)
-            allTofResolutionsThisModuleType.append(tof_resolution_this_pair)
-        allTofBinEdges.append(allTofBinEdgesThisModuleType)
-        allTofResolutions.append(allTofResolutionsThisModuleType)
+            scanner.tof_bin_edges[mtype0][mtype1] = tofBinEdgesThisPair
+            scanner.tof_resolution[mtype0][mtype1] = tof_resolution_this_pair
 
-    allEnergyBinEdges = []
-    allEnergyResolutionsAt511 = []
-    for m_def in module_defs:
-        allEnergyBinEdges.append(
-            petsird.BinEdges(
-                edges=numpy.linspace(m_def.LLD,
-                                     m_def.ULD,
-                                     m_def.number_of_event_energy_bins + 1,
-                                     dtype="float32")))
-        allEnergyResolutionsAt511.append(
-            m_def.energy_resolution)  # as fraction of 511
-
-    # We need energy bin info before being able to construct the detection
-    # efficiencies, so we first construct a scanner without the efficiencies
-    scanner = petsird.ScannerInformation(
-        model_name="PETSIRD_TEST",
-        scanner_geometry=scanner_geometry,
-        tof_bin_edges=allTofBinEdges,
-        tof_resolution=allTofResolutions,
-        event_energy_bin_edges=allEnergyBinEdges,
-        energy_resolution_at_511=allEnergyResolutionsAt511)
+    for mtype, m_def in enumerate(module_defs):
+        scanner.event_energy_bin_edges[mtype] = (petsird.BinEdges(
+            edges=numpy.linspace(m_def.LLD,
+                                 m_def.ULD,
+                                 m_def.number_of_event_energy_bins + 1,
+                                 dtype="float32")))
+        scanner.energy_resolution_at_511[mtype] = (m_def.energy_resolution
+                                                   )  # as fraction of 511
 
     # Now add the efficiencies
-    scanner.detection_efficiencies = get_detection_efficiencies(
-        scanner, module_defs)
+    fill_detection_efficiencies(scanner, module_defs)
 
-    scanner.coincidence_policy = petsird.CoincidencePolicy.REJECT_HIGHER_MULTIPLES
+    scanner.prompt_event_policy = petsird.CoincidencePolicy.REJECT_HIGHER_MULTIPLES
     scanner.single_events_are_stored = False
     scanner.prompt_events_are_stored = True
     scanner.delayed_events_are_stored = False
@@ -478,18 +468,20 @@ def get_events(header: petsird.Header,
                type_of_module_pair: petsird.TypeOfModulePair,
                num_events: int) -> Iterator[petsird.CoincidenceEvent]:
     """Generate some random events"""
-    num_modules0 = len(header.scanner.scanner_geometry.replicated_modules[
-        type_of_module_pair[0]].transforms)
+    type_of_module0 = type_of_module_pair[0]
+    type_of_module1 = type_of_module_pair[1]
+    num_modules0 = len(header.scanner.scanner_geometry.
+                       replicated_modules[type_of_module0].transforms)
     num_detecting_elements0 = len(
-        header.scanner.scanner_geometry.replicated_modules[
-            type_of_module_pair[0]].object.detecting_elements.transforms)
+        header.scanner.scanner_geometry.replicated_modules[type_of_module0].
+        object.detecting_elements.transforms)
     event_energy_bin_edges0 = header.scanner.event_energy_bin_edges[
-        type_of_module_pair[0]]
+        type_of_module0]
     num_event_energy_bins0 = event_energy_bin_edges0.number_of_bins()
-    tof_bin_edges = header.scanner.tof_bin_edges[type_of_module_pair[0]][
-        type_of_module_pair[1]]
+    tof_bin_edges = header.scanner.tof_bin_edges[type_of_module0][
+        type_of_module1]
     num_tof_bins = tof_bin_edges.number_of_bins()
-    count1 = get_num_detection_bins(header.scanner, type_of_module_pair[1])
+    count1 = get_num_detection_bins(header.scanner, type_of_module1)
 
     detection_bins = [petsird.DetectionBin(), petsird.DetectionBin()]
     for _ in range(num_events):
@@ -505,15 +497,16 @@ def get_events(header: petsird.Header,
                 energy_index=get_random_uint(num_event_energy_bins0),
             )
             event.detection_bins[0] = petsird.helpers.make_detection_bin(
-                header.scanner, type_of_module_pair[0],
-                expanded_detection_bin0)
+                header.scanner, type_of_module0, expanded_detection_bin0)
             # TODO move test to separate function
             assert expanded_detection_bin0 == petsird.helpers.expand_detection_bin(
-                header.scanner, type_of_module_pair[0], detection_bins[0])
+                header.scanner, type_of_module0, detection_bins[0])
 
             # short-cut to directly generate a random detection bin
-            event.detection_bins[1] = get_random_uint(count1)
-
+            # Note: we need the events to be ordered
+            max_bin1 = event.detection_bins[
+                0] if type_of_module0 == type_of_module1 else count1
+            event.detection_bins[1] = get_random_uint(max_bin1)
             if get_detection_efficiency(header.scanner, type_of_module_pair,
                                         event) > 0:
                 # in coincidence, we can get out of the loop
@@ -541,7 +534,7 @@ if __name__ == "__main__":
             prompts_this_block = []
             for mtype0 in range(num_types_of_modules):
                 prompts_mod0 = []
-                for mtype1 in range(num_types_of_modules):
+                for mtype1 in range(mtype0 + 1):
                     type_of_module_pair = petsird.TypeOfModulePair(
                         (mtype0, mtype1))
                     prompts_mod0.append(

--- a/python/petsird/helpers/generator.py
+++ b/python/petsird/helpers/generator.py
@@ -403,7 +403,7 @@ def get_scanner_info(
         allocate_module_pair_efficiencies=True)
 
     for mtype0, m_def0 in enumerate(module_defs):
-        for mtype1 in range(num_types_of_modules):  # TODO range(mtype0 + 1):
+        for mtype1 in range(mtype0 + 1):
             m_def1 = module_defs[mtype1]
             # In this example, we determine the coincidence window from the radii.
             # Obviously, a real scanner likely will do something else.

--- a/python/petsird/helpers/generator.py
+++ b/python/petsird/helpers/generator.py
@@ -21,7 +21,8 @@ import numpy
 import petsird
 from petsird.helpers import get_detection_efficiency, get_num_detection_bins
 from petsird.helpers.create import (
-    construct_lower_triangular_or_rectangular_matrix, construct_vector,
+    construct_lower_triangular_or_rectangular_matrix,
+    construct_rectangular_matrix, construct_vector,
     initialize_scanner_information_dimensions)
 
 
@@ -234,12 +235,10 @@ def create_empty_module_pair_efficiencies(scanner: petsird.ScannerInformation,
     num_event_energy_bins1 = event_energy_bin_edges1.number_of_bins()
     size0 = num_det_els_in_module0 * num_event_energy_bins0
     size1 = num_det_els_in_module1 * num_event_energy_bins1
-    module_pair_efficiencies = construct_lower_triangular_or_rectangular_matrix(
-        size0,
-        size1,
-        type_of_module0 == type_of_module1,
-        dtype=float,
-        value=value)
+    module_pair_efficiencies = construct_rectangular_matrix(size0,
+                                                            size1,
+                                                            dtype=float,
+                                                            value=value)
     return module_pair_efficiencies
 
 
@@ -506,7 +505,7 @@ def get_events(header: petsird.Header,
             # Note: we need the events to be ordered
             max_bin1 = event.detection_bins[
                 0] if type_of_module0 == type_of_module1 else count1
-            event.detection_bins[1] = get_random_uint(max_bin1)
+            event.detection_bins[1] = get_random_uint(max_bin1 + 1)
             if get_detection_efficiency(header.scanner, type_of_module_pair,
                                         event) > 0:
                 # in coincidence, we can get out of the loop


### PR DESCRIPTION
Fixes #138
Fixes #171 
Fixes #157

Also
- renamed `moduleCoincidenceAliveTimeFractions` to `modulePairAliveTimeFractions` for consistency with `modulePairEfficiencies`
- changed `SGID` type from `uint` to `int`, as we use -1 to denote "not in coincidence"