### PR TITLE
remove *_are_stored and use the *_policy fields

### DIFF
--- a/cpp/helpers/petsird_analysis.cpp
+++ b/cpp/helpers/petsird_analysis.cpp
@@ -189,12 +189,14 @@ main(int argc, char const* argv[])
                   const petsird::TypeOfModulePair mtype_pair{ mtype0, mtype1 };
                   const auto& energy_mid_points1 = all_energy_mid_points[mtype1];
 
-                  // This code would need work to be able to handle a list-mode file without prompts
+                  // This code would need work to be able to handle a file without prompts
+                  assert(scanner.prompt_event_policy != petsird::CoincidencePolicy::kNone);
+
                   const auto& prompt_events = event_time_block.prompt_events[mtype0][mtype1];
 
                   // count events
                   num_prompts += prompt_events.size();
-                  if (scanner.delayed_events_are_stored)
+                  if (scanner.delayed_event_policy != petsird::CoincidencePolicy::kNone)
                     {
                       num_delayeds += event_time_block.delayed_events[mtype0][mtype1].size();
                     }

--- a/cpp/helpers/petsird_generator.cpp
+++ b/cpp/helpers/petsird_generator.cpp
@@ -259,11 +259,10 @@ get_scanner_info()
   set_detection_efficiencies(scanner_info);
 
   scanner_info.prompt_event_policy = petsird::CoincidencePolicy::kRejectHigherMultiples;
-  scanner_info.single_events_are_stored = false;
-  scanner_info.prompt_events_are_stored = true;
-  scanner_info.delayed_events_are_stored = false;
-  scanner_info.triple_events_are_stored = false;
-  scanner_info.quadruple_events_are_stored = false;
+  scanner_info.single_event_policy = petsird::SingleEventPolicy::kNone;
+  scanner_info.delayed_event_policy = petsird::CoincidencePolicy::kNone;
+  scanner_info.triple_event_policy = petsird::TripleEventPolicy::kNone;
+  scanner_info.quadruple_event_policy = petsird::QuadrupleEventPolicy::kNone;
 
   return scanner_info;
 }

--- a/matlab/toolbox/+petsird/+helpers/generator.m
+++ b/matlab/toolbox/+petsird/+helpers/generator.m
@@ -83,9 +83,11 @@ function scanner = get_scanner_info(cfg)
     % Now add the efficiencies
     scanner.detection_efficiencies = get_detection_efficiencies(scanner, cfg);
 
-    scanner_info.coincidence_policy = petsird.CoincidencePolicy.REJECT_MULTIPLES;
-    scanner_info.delayed_coincidences_are_stored = false;
-    scanner_info.triple_events_are_stored = false;
+    scanner.prompt_event_policy = petsird.CoincidencePolicy.REJECT_HIGHER_MULTIPLES;
+    scanner.single_event_policy = petsird.SingleEventPolicy.NONE;
+    scanner.delayed_event_policy = petsird.CoincidencePolicy.NONE;
+    scanner.triple_event_policy = petsird.TripleEventPolicy.NONE;
+    scanner.quadruple_event_policy = petsird.QuadrupleEventPolicy.NONE;
 
 end
 

--- a/model/Protocol.yml
+++ b/model/Protocol.yml
@@ -54,17 +54,17 @@ EventTimeBlock: !record
    timeInterval: TimeInterval
 
    # nested vector with lists of singles
-   # If ScannerInformation.singleEventsAreStored is False, the vector should have
+   # If ScannerInformation.singleEventsPolicy is SingleEventPolicy.none, the vector should have
    # size 0. Otherwise, there is one separate list for every module type.
    # To get the list of singles for a type of module where the `detectionBin`
    # is in a module of the first type, use
    #  singleEvents[typeOfModule]
-   # Constraint: (size(singleEvents) > 0) == ScannerInformation.singleEventsAreStored
+   # Constraint: (size(singleEvents) > 0) == (ScannerInformation.singleEventsPolicy != SingleEventPolicy.none)
    # Constraint: (size(singleEvents) == 0) || (size(singleEvents) == ScannerInformation.numberOfModuleTypes)
    singleEvents: ListOfSingleEvents*
 
    # nested vector with lists of prompts in this time block
-   # If ScannerInformation.promptEventsAreStored is False, the vector should have
+   # If ScannerInformation.promptEventsPolicy is CoincidencePolicy.none, the vector should have
    # size 0. If not, there is one separate list for every pair of module types.
    # To get the list of prompts for 2 types of modules where the first `detectionBin`
    # given in the `CoincidenceEvent` is in a module of the first type, use
@@ -72,7 +72,7 @@ EventTimeBlock: !record
    # Note that the ListOfCoincidenceEvents could be empty for a particular module-pair.
    # Note that events have to be ordered, i.e.
    #    (typeOfModule1 > typeOfModule2) || (detectionBin1 >= detectionBin2)
-   # Constraint: (size(promptEvents) > 0) == ScannerInformation.promptEventsAreStored
+   # Constraint: (size(promptEvents) > 0) == (ScannerInformation.promptEventsPolicy != CoincidencePolicy.none)
    # Constraint: (size(promptEvents) == 0) || (size(promptsEvents) == ScannerInformation.numberOfModuleTypes)
    # Constraint: (size(promptEvents) == 0) || (size(promptsEvents[typeOfModule1]) == typeOfModule1 + 1)
    promptEvents: LowerTriangularMatrix<ListOfCoincidenceEvents>
@@ -81,7 +81,7 @@ EventTimeBlock: !record
    # To get the list of delayeds for 2 types of modules, use
    #  delayedEvents[typeOfModule1][typeOfModule2]
    # See promptEvents for more information.
-   # Constraint: (size(delayedEvents) > 0) == ScannerInformation.delayedCoincidencesAreStored
+   # Constraint: (size(delayedEvents) > 0) == (ScannerInformation.delayedCoincidencesPolicy != CoincidencePolicy.none)
    # Constraint: (size(delayedEvents) == 0) || (size(delayedEvents) == ScannerInformation.numberOfModuleTypes)
    # Constraint: (size(delayedEvents) == 0) || (size(delayedEvents[typeOfModule1]) == typeOfModule1 + 1)
    delayedEvents: LowerTriangularMatrix<ListOfCoincidenceEvents>
@@ -91,7 +91,7 @@ EventTimeBlock: !record
    #  tripleEvents[typeOfModule1][typeOfModule2][typeOfModule3]
    # Note that events have to be ordered using lexicographical ordering in (typeOfModule_i, detectionBin_i).
    # See promptEvents for more information.
-   # Constraint: (size(tripleEvents) > 0) == ScannerInformation.tripleEventsAreStored
+   # Constraint: (size(tripleEvents) > 0) == (ScannerInformation.tripleEventsPolicy != CoincidencePolicy.none)
    # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents) == ScannerInformation.numberOfModuleTypes)
    # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[typeOfModule1]) == typeOfModule1 + 1)
    # Constraint: (size(tripleEvents) == 0) || (size(tripleEvents[type1][type2]) == type2 + 1)

--- a/model/ScannerInformation.yml
+++ b/model/ScannerInformation.yml
@@ -1,6 +1,9 @@
 # Type definition for how to encode how the scanner records single events (if it does).
 SingleEventPolicy: !enum
   values:
+    # not stored
+    - none
+
     # store all single events
     - all
 
@@ -16,6 +19,9 @@ SingleEventPolicy: !enum
 # that this multiple events are handled, and recorded in the EventTimeBlock.promptEvents field.
 CoincidencePolicy: !enum
   values:
+    # not stored
+    - none
+
     # multiples (more than 2 events in the coincidence window) will be rejected (i.e., not stored in the EventTimeBlock.promptEvents field)
     - rejectHigherMultiples
 
@@ -33,6 +39,9 @@ CoincidencePolicy: !enum
 # Type definition for how to encode how the scanner handles higher order coincidences when recording the triples.
 TripleEventPolicy: !enum
   values:
+    # not stored
+    - none
+
     # quadruples etc are not stored in the EventTimeBlock.tripleEvents field
     - rejectHigherMultiples
 
@@ -42,6 +51,9 @@ TripleEventPolicy: !enum
 # Type definition for how to encode how the scanner handles higher order coincidences when recording the quadruples.
 QuadrupleEventPolicy: !enum
   values:
+    # not stored
+    - none
+
     # quadruples etc are not stored in the EventTimeBlock.quadrupleEvents field
     - rejectHigherMultiples
 
@@ -109,6 +121,7 @@ ScannerInformation: !record
     # Constraint: this 2D array has to be symmetric.
     # Constraint: size(tofBinEdges) == size(ScannerGeometry.replicatedModules)
     # Constraint: size(tofBinEdges[typeOfModule1]) == typeOfModule1 + 1
+    # Constraint: size(tofBinEdges[typeOfModule1]) == typeOfModule1 + 1
     tofBinEdges: LowerTriangularMatrix<BinEdges>
 
     # TOF resolution aka CTR (as FWHM) in mm
@@ -146,39 +159,21 @@ ScannerInformation: !record
     #             (singlesHistogramLevel == SinglesHistogramLevelType.none && size(singlesHistogramEnergyBinEdges) == 0)
     singlesHistogramEnergyBinEdges: BinEdges*
 
-    # Encode how the scanner handles single events in the EventTimeBlock.singleEvents field
+    # Encode if/how the scanner handles single events in the EventTimeBlock.singleEvents field
     singleEventPolicy: SingleEventPolicy
 
-    # Encode how the scanner handles multiple coincidences in the EventTimeBlock.promptEvents field
+    # Encode if/how the scanner handles multiple coincidences in the EventTimeBlock.promptEvents field
     promptEventPolicy: CoincidencePolicy
 
-    # Encode how the scanner handles multiple coincidences in the EventTimeBlock.delayedEvents field
+    # Encode if/how the scanner handles multiple coincidences in the EventTimeBlock.delayedEvents field
     # It is expected that this will have value rejectHigherMultiples, but it is not guaranteed.
     delayedEventPolicy: CoincidencePolicy
 
-    # Encode how the scanner handles higher order coincidences in the EventTimeBlock.tripleEvents field
-    # This field is ignored if tripleEventsAreStored == false.
+    # Encode if/how the scanner handles higher order coincidences in the EventTimeBlock.tripleEvents field
     tripleEventPolicy: TripleEventPolicy
 
-    # Encode how the scanner handles higher order coincidences in the EventTimeBlock.quadrupleEvents field
-    # This field is ignored if quadrupleEventsAreStored == false.
+    # Encode if/how the scanner handles higher order coincidences in the EventTimeBlock.quadrupleEvents field
     quadrupleEventPolicy: QuadrupleEventPolicy
-
-    # a flag to indicate of single events are recorded in the stream (see EventTimeBlock)
-    # Note that this is separate from the singlesHistogramLevel, where singles are histogrammed in a time-block.
-    singleEventsAreStored: bool
-
-    # a flag to indicate of prompt coincidences are recorded in the stream (see EventTimeBlock)
-    promptEventsAreStored: bool
-
-    # a flag to indicate of delayed coincidences are recorded in the stream (see EventTimeBlock)
-    delayedEventsAreStored: bool
-
-    # a flag to indicate of triple events are recorded in the stream (see EventTimeBlock)
-    tripleEventsAreStored: bool
-
-    # a flag to indicate of quadruple coincidences are recorded in the stream (see EventTimeBlock)
-    quadrupleEventsAreStored: bool
 
     # coincidence detection efficiencies
     detectionEfficiencies: DetectionEfficiencies

--- a/python/petsird/helpers/analysis.py
+++ b/python/petsird/helpers/analysis.py
@@ -112,11 +112,15 @@ if __name__ == "__main__":
                         energy_mid_points1 = all_energy_mid_points[mtype1]
                         mtype_pair = petsird.TypeOfModulePair((mtype0, mtype1))
 
-                        # count events
+                        # This code would need work to be able to handle a file
+                        #  without prompts
+                        assert (scanner.prompt_event_policy
+                                != petsird.CoincidencePolicy.NONE)
+
                         prompt_events = time_block.value.prompt_events[mtype0][
                             mtype1]
                         num_prompts += len(prompt_events)
-                        if scanner.delayed_events_are_stored:
+                        if scanner.delayed_event_policy != petsird.CoincidencePolicy.NONE:
                             num_delayeds += len(
                                 time_block.value.delayed_events[mtype0]
                                 [mtype1])

--- a/python/petsird/helpers/generator.py
+++ b/python/petsird/helpers/generator.py
@@ -438,11 +438,10 @@ def get_scanner_info(
     fill_detection_efficiencies(scanner, module_defs)
 
     scanner.prompt_event_policy = petsird.CoincidencePolicy.REJECT_HIGHER_MULTIPLES
-    scanner.single_events_are_stored = False
-    scanner.prompt_events_are_stored = True
-    scanner.delayed_events_are_stored = False
-    scanner.triple_events_are_stored = False
-    scanner.quadruple_events_are_stored = False
+    scanner.single_event_policy = petsird.SingleEventPolicy.NONE
+    scanner.delayed_event_policy = petsird.CoincidencePolicy.NONE
+    scanner.triple_event_policy = petsird.TripleEventPolicy.NONE
+    scanner.quadruple_event_policy = petsird.QuadrupleEventPolicy.NONE
 
     return scanner
 


### PR DESCRIPTION
- add an option `none` to the `*Policy` enums
- remove the `*are_stored` fields and encode the information in the `_policy` fields instead

Fixes #194

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
