### PR TITLE
CI: remove unused library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       run: just run-cpp
     - name: Build cpp example
       run: |
+        rm cpp/install/lib/libpetsird.a # unused static lib
         just cmake_source_dir=ccp/example cmake_build_dir=cpp/example/build build-cpp
     - id: prep
       name: Prepare deployment


### PR DESCRIPTION
As per https://github.com/ETSInitiative/PETSIRD/pull/199#issuecomment-5331997866 it seems the static lib is a CMake build hack which isn't actually necessary nor desired for distribution in a header-only package.

This PR:

- reduces package size from 17MB to 0.5MB (`tar.gz` from 1.8MB to 0.066MB)
- tests that `cpp/examples` still builds *sans* `libpetsird.a`